### PR TITLE
fix: resolve dashboard cash flow chart e2e test failure

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -61,8 +61,8 @@ test.describe('Dashboard Visualization', () => {
     await page.waitForLoadState('networkidle');
 
     // The CashFlowChart component uses recharts
-    // Look for chart heading or container
-    await expect(page.getByText(/cash flow/i).or(page.getByText(/monthly/i))).toBeVisible();
+    // Look for the specific "Cash Flow Over Time" heading
+    await expect(page.getByRole('heading', { name: 'Cash Flow Over Time' })).toBeVisible();
 
     // Verify no chart loading errors
     await expect(page.getByText(/failed to load/i)).not.toBeVisible();


### PR DESCRIPTION
## Summary

Fixes the failing "should render cash flow chart" test in `dashboard.spec.ts` by replacing a non-specific selector that matched multiple elements with a precise selector.

## Problem

The test was failing due to a Playwright strict mode violation. The selector `getByText(/cash flow/i).or(page.getByText(/monthly/i))` matched 5 elements:
1. "Monthly Income" heading
2. "Monthly Expenses" heading  
3. "Net Cash Flow" heading
4. "Cash Flow Over Time" heading (the intended target)
5. "Monthly Salary" table cell

Playwright's strict mode requires selectors to match exactly one element, causing the test to fail.

## Solution

Replaced the non-specific selector with:
```typescript
getByRole('heading', { name: 'Cash Flow Over Time' })
```

This precisely targets the cash flow chart heading without ambiguity.

## Testing

- ✅ Specific test now passes: `npm run test:e2e -- dashboard.spec.ts -g "should render cash flow chart"`
- ✅ All 12 dashboard tests pass with no regressions
- ✅ Test follows Playwright best practices for element selection

## Files Changed

- `e2e/dashboard.spec.ts` - Updated line 65 with specific selector

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)