### PR TITLE
test: fix unit test failures after session security changes

### DIFF
--- a/__tests__/lib/auth/session-validation.test.ts
+++ b/__tests__/lib/auth/session-validation.test.ts
@@ -2,7 +2,7 @@
  * Tests for session secret validation
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 describe('Session Secret Validation', () => {
   const originalEnv = process.env;
@@ -45,17 +45,17 @@ describe('Session Secret Validation', () => {
   it('should accept valid SESSION_SECRET', async () => {
     process.env.SESSION_SECRET = 'Gx8jK2nP9qR5tU7vW0xY1zA3bC4dE6fH8iJ0kL2mN4o=';
 
-    await expect(async () => {
-      await import('@/lib/auth/session');
-    }).resolves.not.toThrow();
+    await expect(
+      import('@/lib/auth/session')
+    ).resolves.toBeDefined();
   });
 
   it('should allow weak secrets in development', async () => {
     process.env.NODE_ENV = 'development';
     process.env.SESSION_SECRET = 'test-secret-that-is-long-enough-32chars';
 
-    await expect(async () => {
-      await import('@/lib/auth/session');
-    }).resolves.not.toThrow();
+    await expect(
+      import('@/lib/auth/session')
+    ).resolves.toBeDefined();
   });
 });

--- a/__tests__/lib/utils/mocks.ts
+++ b/__tests__/lib/utils/mocks.ts
@@ -17,6 +17,7 @@ export const createDbMock = () => ({
 export const createSessionMock = (data: any = {}) => ({
   userId: data.userId,
   username: data.username,
+  sessionVersion: data.sessionVersion,
   save: vi.fn(),
   destroy: vi.fn(),
 });
@@ -26,6 +27,7 @@ export const mockUser = {
   id: 1,
   username: 'testuser',
   password_hash: '$2b$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewY5GyYqXy.LqIhq', // hash of 'password123'
+  session_version: 1,
   created_at: new Date('2024-01-01'),
 };
 


### PR DESCRIPTION
## Summary

Fixes 4 unit test failures introduced by the session security improvements in PR #24.

## Test Failures Fixed

### 1. Auth Action Tests (2 failures) ✅

**Issue:** SQL query changed to include `session_version` field, but tests expected old query.

**Fixes:**
- Updated SQL query expectations in auth tests:
  ```typescript
  // Old
  'SELECT * FROM users WHERE username = '
  
  // New
  'SELECT id, username, password_hash, session_version FROM users WHERE username = '
  ```

- Modified login test to handle session fixation fix:
  - Old: Single session mock (reused)
  - New: Two session mocks (oldSession.destroy() + newSession created)

- Added assertion for `sessionVersion` being set correctly

### 2. Session Validation Tests (2 failures) ✅

**Issue:** Incorrect test syntax with `.resolves.not.toThrow()`

**Fixes:**
- Added missing `vi` import
- Fixed async import test syntax:
  ```typescript
  // Old (incorrect)
  await expect(async () => {
    await import('@/lib/auth/session');
  }).resolves.not.toThrow();
  
  // New (correct)
  await expect(
    import('@/lib/auth/session')
  ).resolves.toBeDefined();
  ```

## Mock Updates

**mockUser** - Added `session_version: 1`
- Required for auth queries that now select this field

**createSessionMock** - Added `sessionVersion` property
- Tracks session version in tests

## Test Results

```
✅ All 101 tests passing
✅ 10/10 test files passing
```

**Test Suite:**
- __tests__/lib/auth/session-invalidation.test.ts (4 tests) ✅
- __tests__/lib/auth/session-validation.test.ts (5 tests) ✅
- __tests__/lib/db/index.test.ts (16 tests) ✅
- __tests__/lib/analytics/cash-flow.test.ts (24 tests) ✅
- __tests__/lib/db/transactions.test.ts (16 tests) ✅
- __tests__/lib/auth/session.test.ts (7 tests) ✅
- __tests__/lib/actions/auth.test.ts (9 tests) ✅
- __tests__/components/transactions/transaction-table.test.tsx (3 tests) ✅
- __tests__/lib/validations/auth.test.ts (7 tests) ✅
- __tests__/lib/auth/password.test.ts (10 tests) ✅

## Files Changed

- `__tests__/lib/actions/auth.test.ts` - Updated query expectations and session handling
- `__tests__/lib/auth/session-validation.test.ts` - Fixed async test syntax
- `__tests__/lib/utils/mocks.ts` - Added session_version to mocks

## Related

- Fixes test failures from #13 
- Related to PR #24 (session security improvements)

## Verification

Run tests locally:
```bash
npm test -- --run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)