### PR TITLE
fix: use extracted payee from memo in OFX imports

### DIFF
--- a/lib/actions/ofx-import.ts
+++ b/lib/actions/ofx-import.ts
@@ -36,9 +36,9 @@ async function insertTransaction(
     [
       accountId,
       tx.date,
-      tx.refnum,
+      tx.payee ?? '',
       tx.amount.toFixed(2),
-      tx.memo,
+      tx.payee ? tx.cleanedMemo : tx.memo,
       tx.fitid,
       tx.memo,
       tx.refnum,

--- a/lib/ofx/parser.ts
+++ b/lib/ofx/parser.ts
@@ -1,5 +1,6 @@
 import { parse as parseOfx } from 'ofx-parser';
 import { ParsedOfxImport, OfxTransaction } from './types';
+import { extractPayeeFromMemo } from './utils';
 
 function parseOfxDate(dateStr: string | Date): string {
   const dateString = dateStr instanceof Date ? dateStr.toISOString() : String(dateStr);
@@ -53,11 +54,14 @@ export async function parseOfxFile(content: string): Promise<ParsedOfxImport> {
       const amount = parseAmount(txObj.TRNAMT as string | number);
       const refnum = String(txObj.REFNUM || cleanFitid);
       const memo = String(txObj.MEMO || '');
+      const { payee: extractedPayee, cleanedMemo } = extractPayeeFromMemo(memo);
 
       return {
         fitid: cleanFitid,
         refnum,
         memo,
+        payee: extractedPayee,
+        cleanedMemo,
         date: parseOfxDate(txObj.DTPOSTED as string | Date),
         amount,
         type: trnType.toUpperCase() === 'CREDIT' ? 'CREDIT' : 'DEBIT',

--- a/lib/ofx/types.ts
+++ b/lib/ofx/types.ts
@@ -2,6 +2,8 @@ export interface OfxTransaction {
   fitid: string;
   refnum: string;
   memo: string;
+  payee: string | null;
+  cleanedMemo: string;
   date: string; // YYYY-MM-DD
   amount: number; // positive = credit, negative = debit
   type: 'CREDIT' | 'DEBIT';


### PR DESCRIPTION
## Summary
- Integrate `extractPayeeFromMemo` utility into OFX parser to properly extract payee from memo field
- Use extracted payee (or empty string if not found) instead of refnum for transaction payee
- Use cleanedMemo (memo without CPF/CNPJ) for comment when payee is extracted
- Also install missing `ofx-parser` dependency