### PR TITLE
fix: set httpOnly on locale cookie for security

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -104,9 +104,9 @@ export function middleware(request: NextRequest) {
       name: LOCALE_COOKIE,
       value: locale,
       path: '/',
-      httpOnly: false,
+      httpOnly: true,
       sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 365, 
+      maxAge: 60 * 60 * 24 * 365,
     });
   }
 


### PR DESCRIPTION
Fixes #60

## Summary
- Changed `httpOnly: false` to `httpOnly: true` on the locale cookie in middleware.ts
- This is a defense-in-depth security measure to prevent JavaScript access to the cookie

## Test Plan
- Build passes successfully
- Lint passes
- Cookie will now be inaccessible to client-side JavaScript (httpOnly flag set)