### PR TITLE
feat: change cash flow chart to display daily values

### DIFF
--- a/__tests__/lib/analytics/cash-flow.test.ts
+++ b/__tests__/lib/analytics/cash-flow.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   getAccountSummary,
   getMonthlyCashFlow,
+  getDailyCashFlow,
   getCategoryBreakdown,
 } from '@/lib/analytics/cash-flow';
 import {
   mockAccountSummary,
   mockMonthlyData,
+  mockDailyData,
   mockCategoryBreakdown,
 } from '../utils/mocks';
 
@@ -199,6 +201,90 @@ describe('Cash Flow Analytics', () => {
         expect.any(String),
         [1]
       );
+    });
+  });
+
+  describe('getDailyCashFlow', () => {
+    it('should return daily cash flow data', async () => {
+      const { queryMany } = await import('@/lib/db');
+
+      vi.mocked(queryMany).mockResolvedValue(mockDailyData);
+
+      const result = await getDailyCashFlow();
+
+      expect(result).toEqual(mockDailyData);
+      expect(result).toHaveLength(2);
+    });
+
+    it('should use default 30 days when no parameter provided', async () => {
+      const { queryMany } = await import('@/lib/db');
+
+      vi.mocked(queryMany).mockResolvedValue(mockDailyData);
+
+      await getDailyCashFlow();
+
+      expect(queryMany).toHaveBeenCalledWith(
+        expect.any(String),
+        [30]
+      );
+    });
+
+    it('should accept custom day range', async () => {
+      const { queryMany } = await import('@/lib/db');
+
+      vi.mocked(queryMany).mockResolvedValue(mockDailyData);
+
+      await getDailyCashFlow(7);
+
+      expect(queryMany).toHaveBeenCalledWith(
+        expect.any(String),
+        [7]
+      );
+    });
+
+    it('should return data in YYYY-MM-DD format', async () => {
+      const { queryMany } = await import('@/lib/db');
+
+      vi.mocked(queryMany).mockResolvedValue(mockDailyData);
+
+      const result = await getDailyCashFlow();
+
+      expect(result[0].date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('should separate income and expenses', async () => {
+      const { queryMany } = await import('@/lib/db');
+
+      vi.mocked(queryMany).mockResolvedValue(mockDailyData);
+
+      const result = await getDailyCashFlow();
+
+      expect(result[0]).toHaveProperty('income');
+      expect(result[0]).toHaveProperty('expenses');
+      expect(result[0]).toHaveProperty('net');
+    });
+
+    it('should order by date DESC', async () => {
+      const { queryMany } = await import('@/lib/db');
+
+      vi.mocked(queryMany).mockResolvedValue(mockDailyData);
+
+      await getDailyCashFlow();
+
+      expect(queryMany).toHaveBeenCalledWith(
+        expect.stringContaining('ORDER BY date DESC'),
+        [30]
+      );
+    });
+
+    it('should return empty array when no data', async () => {
+      const { queryMany } = await import('@/lib/db');
+
+      vi.mocked(queryMany).mockResolvedValue([]);
+
+      const result = await getDailyCashFlow();
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/__tests__/lib/utils/mocks.ts
+++ b/__tests__/lib/utils/mocks.ts
@@ -108,3 +108,18 @@ export const mockAccountSummary = {
   monthly_expenses: '3000.00',
   net_cash_flow: '2000.00',
 };
+
+export const mockDailyData = [
+  {
+    date: '2024-01-15',
+    income: '500.00',
+    expenses: '300.00',
+    net: '200.00',
+  },
+  {
+    date: '2024-01-14',
+    income: '450.00',
+    expenses: '280.00',
+    net: '170.00',
+  },
+];

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -5,14 +5,14 @@ import { CashFlowChart } from '@/components/dashboard/cash-flow-chart';
 import { CategoryChart } from '@/components/dashboard/category-chart';
 import { RecentTransactions } from '@/components/dashboard/recent-transactions';
 import {
-  getMonthlyCashFlow,
+  getDailyCashFlow,
   getCategoryBreakdown,
 } from '@/lib/analytics/cash-flow';
 
 export default async function DashboardPage() {
   const t = await getTranslations('dashboard');
-  const [monthlyData, expenseBreakdown, incomeBreakdown] = await Promise.all([
-    getMonthlyCashFlow(6),
+  const [dailyData, expenseBreakdown, incomeBreakdown] = await Promise.all([
+    getDailyCashFlow(30),
     getCategoryBreakdown('expense', 5),
     getCategoryBreakdown('income', 5),
   ]);
@@ -25,7 +25,7 @@ export default async function DashboardPage() {
         <SummaryCards />
       </Suspense>
 
-      <CashFlowChart data={monthlyData} />
+      <CashFlowChart data={dailyData} />
 
       <div className="grid gap-6 md:grid-cols-2">
         <CategoryChart

--- a/components/dashboard/cash-flow-chart.tsx
+++ b/components/dashboard/cash-flow-chart.tsx
@@ -13,21 +13,19 @@ import {
 } from 'recharts';
 
 interface CashFlowChartProps {
-  data: Array<{
-    month: string;
-    income: string;
-    expenses: string;
-    net: string;
-  }>;
+  data: Array<
+    | { month: string; income: string; expenses: string; net: string }
+    | { date: string; income: string; expenses: string; net: string }
+  >;
 }
 
 export function CashFlowChart({ data }: CashFlowChartProps) {
   const chartData = data.map((item) => ({
-    month: item.month,
+    period: 'month' in item ? item.month : item.date,
     Income: parseFloat(item.income),
     Expenses: parseFloat(item.expenses),
     Net: parseFloat(item.net),
-  })).reverse(); // Show oldest to newest
+  })).reverse();
 
   return (
     <Card>
@@ -38,7 +36,7 @@ export function CashFlowChart({ data }: CashFlowChartProps) {
         <ResponsiveContainer width="100%" height={300}>
           <LineChart data={chartData}>
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" />
+            <XAxis dataKey="period" />
             <YAxis />
             <Tooltip />
             <Legend />

--- a/e2e/04-dashboard.spec.ts
+++ b/e2e/04-dashboard.spec.ts
@@ -49,14 +49,10 @@ test.describe('Dashboard Visualization', () => {
   });
 
   test('should render cash flow chart', async ({ page }) => {
-    // Wait for the page to fully load
     await page.waitForLoadState('networkidle');
 
-    // The CashFlowChart component uses recharts
-    // Look for the specific "Cash Flow Over Time" heading
     await expect(page.getByRole('heading', { name: 'Cash Flow Over Time' })).toBeVisible();
 
-    // Verify no chart loading errors
     await expect(page.getByText(/failed to load/i)).not.toBeVisible();
   });
 

--- a/lib/analytics/cash-flow.ts
+++ b/lib/analytics/cash-flow.ts
@@ -1,5 +1,5 @@
 import { queryMany, queryOne } from '@/lib/db';
-import { MonthlyData, CategoryBreakdown, AccountSummary } from './types';
+import { MonthlyData, DailyData, CategoryBreakdown, AccountSummary } from './types';
 
 export async function getAccountSummary(): Promise<AccountSummary> {
   const result = await queryOne<AccountSummary>(
@@ -49,6 +49,24 @@ export async function getMonthlyCashFlow(
      GROUP BY DATE_TRUNC('month', t.date)
      ORDER BY month DESC`,
     [months]
+  );
+}
+
+export async function getDailyCashFlow(
+  days: number = 30
+): Promise<DailyData[]> {
+  return queryMany<DailyData>(
+    `SELECT
+       TO_CHAR(t.date, 'YYYY-MM-DD') as date,
+       COALESCE(SUM(CASE WHEN c.category_type = 'income' THEN t.amount ELSE 0 END), 0)::decimal(15,2) as income,
+       COALESCE(ABS(SUM(CASE WHEN c.category_type = 'expense' THEN t.amount ELSE 0 END)), 0)::decimal(15,2) as expenses,
+       COALESCE(SUM(t.amount), 0)::decimal(15,2) as net
+     FROM transactions t
+     LEFT JOIN categories c ON t.category_id = c.id
+     WHERE t.date >= CURRENT_DATE - INTERVAL '1 day' * $1
+     GROUP BY t.date
+     ORDER BY date DESC`,
+    [days]
   );
 }
 

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -5,6 +5,13 @@ export interface MonthlyData {
   net: string;
 }
 
+export interface DailyData {
+  date: string; // YYYY-MM-DD format
+  income: string;
+  expenses: string;
+  net: string;
+}
+
 export interface CategoryBreakdown {
   category_id: number | null;
   category_name: string;


### PR DESCRIPTION
## Summary
- Changed Cash Flow Over Time chart from monthly to daily aggregation
- Added `getDailyCashFlow()` function that fetches transaction data grouped by day (default 30 days)
- Updated CashFlowChart component to handle both monthly and daily data formats
- Added comprehensive unit tests for the new function

## Changes
- `lib/analytics/types.ts`: Added `DailyData` interface
- `lib/analytics/cash-flow.ts`: Added `getDailyCashFlow(days)` function
- `components/dashboard/cash-flow-chart.tsx`: Updated to accept daily data
- `app/(dashboard)/page.tsx`: Switched from `getMonthlyCashFlow(6)` to `getDailyCashFlow(30)`

Fixes #47