### PR TITLE
feat: add transaction analysis view

### DIFF
--- a/__tests__/app/analysis-client.test.tsx
+++ b/__tests__/app/analysis-client.test.tsx
@@ -377,6 +377,29 @@ describe('AnalysisClient', () => {
     expect(pushedParams.get('lang')).toBe('en');
   });
 
+  it('does not reuse stale account filters after props reset to defaults', async () => {
+    const { rerender } = renderClient({ ...filters, accountId: 2 });
+
+    rerender(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AnalysisClient
+          accounts={accounts}
+          categories={categories}
+          filters={filters}
+          data={data}
+          lang="en"
+        />
+      </NextIntlClientProvider>
+    );
+
+    await selectOption(screen.getByRole('combobox', { name: 'Grouping' }), 'Monthly');
+
+    const { pushedParams } = getPushedParams();
+    expect(pushedParams.has('accountId')).toBe(false);
+    expect(pushedParams.get('grouping')).toBe('monthly');
+    expect(pushedParams.get('lang')).toBe('en');
+  });
+
   it('clears category params when the selection returns to the default filter', async () => {
     const user = userEvent.setup();
     setSearchParams('lang=en&categories=10&uncategorizedIncome=0&uncategorizedExpense=0');

--- a/__tests__/app/analysis-client.test.tsx
+++ b/__tests__/app/analysis-client.test.tsx
@@ -229,23 +229,34 @@ describe('AnalysisClient', () => {
       { period: '2026-04', income: '500.00', expenses: '200.00' },
     ],
     incomeBreakdown: [
-      { categoryId: 10, categoryName: 'Salary', categoryPath: 'Salary', total: '10200.00' },
+      {
+        category_id: 10,
+        category_name: 'Salary',
+        category_path: 'Salary',
+        amount: '10200.00',
+        percentage: 100,
+      },
     ],
     expenseBreakdown: [
-      { categoryId: 20, categoryName: 'Rent', categoryPath: 'Rent', total: '4300.00' },
+      {
+        category_id: 20,
+        category_name: 'Rent',
+        category_path: 'Rent',
+        amount: '4300.00',
+        percentage: 100,
+      },
     ],
     incomeStackedTrend: [
-      { period: '2026-04', categories: { Salary: '5000.00' } },
+      { period: '2026-04', Salary: '5000.00' },
     ],
     expenseStackedTrend: [
-      { period: '2026-04', categories: { Rent: '2200.00' } },
+      { period: '2026-04', Rent: '2200.00' },
     ],
     categoryTrends: [
       {
-        categoryId: 10,
-        categoryName: 'Salary',
-        categoryPath: 'Salary',
+        categoryKey: 'income-10',
         categoryType: 'income',
+        categoryPath: 'Salary',
         total: '10200.00',
         periods: { '2026-04': '5000.00', '2026-05': '5200.00' },
       },

--- a/__tests__/app/analysis-client.test.tsx
+++ b/__tests__/app/analysis-client.test.tsx
@@ -60,7 +60,7 @@ vi.mock('@/components/analysis/category-stacked-trend-chart', () => ({
     <section
       data-testid="stacked-trend-chart"
       data-locale={locale}
-      data-points={data.length}
+      data-points={data.points.length}
     >
       {title}
     </section>
@@ -246,12 +246,14 @@ describe('AnalysisClient', () => {
         percentage: 100,
       },
     ],
-    incomeStackedTrend: [
-      { period: '2026-04', Salary: '5000.00' },
-    ],
-    expenseStackedTrend: [
-      { period: '2026-04', Rent: '2200.00' },
-    ],
+    incomeStackedTrend: {
+      series: [{ key: 'income-10', name: 'Salary' }],
+      points: [{ period: '2026-04', values: { 'income-10': '5000.00' } }],
+    },
+    expenseStackedTrend: {
+      series: [{ key: 'expense-20', name: 'Rent' }],
+      points: [{ period: '2026-04', values: { 'expense-20': '2200.00' } }],
+    },
     categoryTrends: [
       {
         categoryKey: 'income-10',

--- a/__tests__/app/analysis-client.test.tsx
+++ b/__tests__/app/analysis-client.test.tsx
@@ -22,26 +22,101 @@ vi.mock('@/components/analysis/analysis-summary-cards', () => ({
 }));
 
 vi.mock('@/components/analysis/income-expense-trend-chart', () => ({
-  IncomeExpenseTrendChart: ({ title }: { title: string }) => (
-    <section data-testid="income-expense-chart">{title}</section>
+  IncomeExpenseTrendChart: ({
+    data,
+    labels,
+    locale,
+    title,
+  }: {
+    data: TransactionAnalysisData['incomeExpenseTrend'];
+    labels: { income: string; expenses: string };
+    locale: string;
+    title: string;
+  }) => (
+    <section
+      data-testid="income-expense-chart"
+      data-locale={locale}
+      data-points={data.length}
+      data-income-label={labels.income}
+      data-expenses-label={labels.expenses}
+    >
+      {title}
+    </section>
   ),
 }));
 
 vi.mock('@/components/analysis/category-stacked-trend-chart', () => ({
-  CategoryStackedTrendChart: ({ title }: { title: string }) => (
-    <section data-testid="stacked-trend-chart">{title}</section>
+  CategoryStackedTrendChart: ({
+    data,
+    locale,
+    title,
+  }: {
+    data:
+      | TransactionAnalysisData['incomeStackedTrend']
+      | TransactionAnalysisData['expenseStackedTrend'];
+    locale: string;
+    title: string;
+  }) => (
+    <section
+      data-testid="stacked-trend-chart"
+      data-locale={locale}
+      data-points={data.length}
+    >
+      {title}
+    </section>
   ),
 }));
 
 vi.mock('@/components/analysis/category-breakdown-chart', () => ({
-  CategoryBreakdownChart: ({ title }: { title: string }) => (
-    <section data-testid="breakdown-chart">{title}</section>
+  CategoryBreakdownChart: ({
+    color,
+    data,
+    locale,
+    title,
+  }: {
+    color: string;
+    data:
+      | TransactionAnalysisData['incomeBreakdown']
+      | TransactionAnalysisData['expenseBreakdown'];
+    locale: string;
+    title: string;
+  }) => (
+    <section
+      data-testid="breakdown-chart"
+      data-color={color}
+      data-locale={locale}
+      data-points={data.length}
+    >
+      {title}
+    </section>
   ),
 }));
 
 vi.mock('@/components/analysis/category-trend-table', () => ({
-  CategoryTrendTable: ({ title }: { title: string }) => (
-    <section data-testid="trend-table">{title}</section>
+  CategoryTrendTable: ({
+    labels,
+    locale,
+    periods,
+    rows,
+    title,
+  }: {
+    labels: { category: string; type: string; total: string };
+    locale: string;
+    periods: string[];
+    rows: TransactionAnalysisData['categoryTrends'];
+    title: string;
+  }) => (
+    <section
+      data-testid="trend-table"
+      data-category-label={labels.category}
+      data-locale={locale}
+      data-periods={periods.join('|')}
+      data-rows={rows.length}
+      data-total-label={labels.total}
+      data-type-label={labels.type}
+    >
+      {title}
+    </section>
   ),
 }));
 
@@ -150,12 +225,31 @@ describe('AnalysisClient', () => {
     summary: { income: '5000.00', expenses: '2200.00' },
     incomeExpenseTrend: [
       { period: '2026-04', income: '5000.00', expenses: '2200.00' },
+      { period: '2026-05', income: '5200.00', expenses: '2100.00' },
+      { period: '2026-04', income: '500.00', expenses: '200.00' },
     ],
-    incomeBreakdown: [],
-    expenseBreakdown: [],
-    incomeStackedTrend: [],
-    expenseStackedTrend: [],
-    categoryTrends: [],
+    incomeBreakdown: [
+      { categoryId: 10, categoryName: 'Salary', categoryPath: 'Salary', total: '10200.00' },
+    ],
+    expenseBreakdown: [
+      { categoryId: 20, categoryName: 'Rent', categoryPath: 'Rent', total: '4300.00' },
+    ],
+    incomeStackedTrend: [
+      { period: '2026-04', categories: { Salary: '5000.00' } },
+    ],
+    expenseStackedTrend: [
+      { period: '2026-04', categories: { Rent: '2200.00' } },
+    ],
+    categoryTrends: [
+      {
+        categoryId: 10,
+        categoryName: 'Salary',
+        categoryPath: 'Salary',
+        categoryType: 'income',
+        total: '10200.00',
+        periods: { '2026-04': '5000.00', '2026-05': '5200.00' },
+      },
+    ],
   };
 
   beforeEach(() => {
@@ -178,6 +272,12 @@ describe('AnalysisClient', () => {
     );
   });
 
+  function setSearchParams(params: string) {
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams(params) as ReturnType<typeof useSearchParams>
+    );
+  }
+
   function renderClient(nextFilters: AnalysisFilters = filters) {
     return render(
       <NextIntlClientProvider locale="en" messages={messages}>
@@ -196,6 +296,15 @@ describe('AnalysisClient', () => {
     const user = userEvent.setup();
     await user.click(trigger);
     await user.click(await screen.findByRole('option', { name }));
+  }
+
+  function getPushedParams(callIndex = -1) {
+    const pushedUrl = routerPush.mock.calls.at(callIndex)?.[0] as string;
+
+    return {
+      pushedUrl,
+      pushedParams: new URLSearchParams(pushedUrl.split('?')[1]),
+    };
   }
 
   it('renders the page sections', () => {
@@ -229,6 +338,120 @@ describe('AnalysisClient', () => {
     expect(pushedUrl.startsWith('/analysis?')).toBe(true);
     expect(pushedParams.get('accountId')).toBe('2');
     expect(pushedParams.get('lang')).toBe('en');
+  });
+
+  it('pushes both current dates when selecting the custom preset', async () => {
+    renderClient();
+
+    await selectOption(screen.getByRole('combobox', { name: 'Date range' }), 'Custom');
+
+    const { pushedParams } = getPushedParams();
+    expect(pushedParams.get('preset')).toBe('custom');
+    expect(pushedParams.get('from')).toBe('2026-02-10');
+    expect(pushedParams.get('to')).toBe('2026-05-10');
+    expect(pushedParams.get('lang')).toBe('en');
+  });
+
+  it('pushes both dates when editing one custom date input', async () => {
+    const user = userEvent.setup();
+    renderClient();
+
+    await user.clear(screen.getByLabelText('From'));
+    await user.type(screen.getByLabelText('From'), '2026-01-15');
+
+    const { pushedParams } = getPushedParams();
+    expect(pushedParams.get('preset')).toBe('custom');
+    expect(pushedParams.get('from')).toBe('2026-01-15');
+    expect(pushedParams.get('to')).toBe('2026-05-10');
+  });
+
+  it('preserves prior filter changes across quick successive URL updates', async () => {
+    renderClient();
+
+    await selectOption(screen.getByRole('combobox', { name: 'Account' }), 'Savings Account');
+    await selectOption(screen.getByRole('combobox', { name: 'Grouping' }), 'Monthly');
+
+    const { pushedParams } = getPushedParams();
+    expect(pushedParams.get('accountId')).toBe('2');
+    expect(pushedParams.get('grouping')).toBe('monthly');
+    expect(pushedParams.get('lang')).toBe('en');
+  });
+
+  it('clears category params when the selection returns to the default filter', async () => {
+    const user = userEvent.setup();
+    setSearchParams('lang=en&categories=10&uncategorizedIncome=0&uncategorizedExpense=0');
+    renderClient({
+      ...filters,
+      includedCategoryIds: [10],
+      hasCategoryFilter: true,
+      includeUncategorizedIncome: false,
+      includeUncategorizedExpense: false,
+    });
+
+    await user.click(screen.getByRole('checkbox', { name: 'Rent' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Uncategorized income' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Uncategorized expense' }));
+
+    const { pushedParams } = getPushedParams();
+    expect(pushedParams.has('categories')).toBe(false);
+    expect(pushedParams.has('uncategorizedIncome')).toBe(false);
+    expect(pushedParams.has('uncategorizedExpense')).toBe(false);
+    expect(pushedParams.get('lang')).toBe('en');
+  });
+
+  it('writes sorted category params and disabled uncategorized flags', async () => {
+    const user = userEvent.setup();
+    renderClient();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Salary' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Uncategorized expense' }));
+
+    const { pushedParams } = getPushedParams();
+    expect(pushedParams.get('categories')).toBe('20');
+    expect(pushedParams.has('uncategorizedIncome')).toBe(false);
+    expect(pushedParams.get('uncategorizedExpense')).toBe('0');
+    expect(pushedParams.get('lang')).toBe('en');
+  });
+
+  it('forwards chart props and derives table periods from income-expense trend data', () => {
+    renderClient();
+
+    expect(screen.getByTestId('income-expense-chart')).toHaveAttribute(
+      'data-points',
+      '3'
+    );
+    expect(screen.getByTestId('income-expense-chart')).toHaveAttribute(
+      'data-income-label',
+      'Income'
+    );
+    expect(screen.getByTestId('income-expense-chart')).toHaveAttribute(
+      'data-expenses-label',
+      'Expenses'
+    );
+
+    const stackedCharts = screen.getAllByTestId('stacked-trend-chart');
+    expect(stackedCharts[0]).toHaveAttribute('data-points', '1');
+    expect(stackedCharts[1]).toHaveAttribute('data-points', '1');
+
+    const breakdownCharts = screen.getAllByTestId('breakdown-chart');
+    expect(breakdownCharts[0]).toHaveAttribute('data-color', '#22c55e');
+    expect(breakdownCharts[0]).toHaveAttribute('data-points', '1');
+    expect(breakdownCharts[1]).toHaveAttribute('data-color', '#ef4444');
+    expect(breakdownCharts[1]).toHaveAttribute('data-points', '1');
+
+    expect(screen.getByTestId('trend-table')).toHaveAttribute(
+      'data-periods',
+      '2026-04|2026-05'
+    );
+    expect(screen.getByTestId('trend-table')).toHaveAttribute('data-rows', '1');
+    expect(screen.getByTestId('trend-table')).toHaveAttribute(
+      'data-category-label',
+      'Category'
+    );
+    expect(screen.getByTestId('trend-table')).toHaveAttribute(
+      'data-total-label',
+      'Total'
+    );
   });
 
   it('resets filters to the analysis page with lang', async () => {

--- a/__tests__/app/analysis-client.test.tsx
+++ b/__tests__/app/analysis-client.test.tsx
@@ -1,0 +1,242 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { NextIntlClientProvider } from 'next-intl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnalysisClient } from '@/app/(dashboard)/analysis/client';
+import type { AnalysisFilters } from '@/lib/analysis/filters';
+import type { TransactionAnalysisData } from '@/lib/analytics/transaction-analysis';
+import type { Account, CategoryWithPath } from '@/lib/db/types';
+
+vi.mock('@/components/analysis/analysis-summary-cards', () => ({
+  AnalysisSummaryCards: ({
+    labels,
+  }: {
+    labels: { income: string; expenses: string };
+  }) => (
+    <section data-testid="summary-cards">
+      <h3>{labels.income}</h3>
+      <h3>{labels.expenses}</h3>
+    </section>
+  ),
+}));
+
+vi.mock('@/components/analysis/income-expense-trend-chart', () => ({
+  IncomeExpenseTrendChart: ({ title }: { title: string }) => (
+    <section data-testid="income-expense-chart">{title}</section>
+  ),
+}));
+
+vi.mock('@/components/analysis/category-stacked-trend-chart', () => ({
+  CategoryStackedTrendChart: ({ title }: { title: string }) => (
+    <section data-testid="stacked-trend-chart">{title}</section>
+  ),
+}));
+
+vi.mock('@/components/analysis/category-breakdown-chart', () => ({
+  CategoryBreakdownChart: ({ title }: { title: string }) => (
+    <section data-testid="breakdown-chart">{title}</section>
+  ),
+}));
+
+vi.mock('@/components/analysis/category-trend-table', () => ({
+  CategoryTrendTable: ({ title }: { title: string }) => (
+    <section data-testid="trend-table">{title}</section>
+  ),
+}));
+
+const messages = {
+  analysis: {
+    title: 'Analysis',
+    description: 'Explore income and expense trends.',
+    filters: 'Filters',
+    dateRangePreset: 'Date range',
+    from: 'From',
+    to: 'To',
+    account: 'Account',
+    allAccounts: 'All accounts',
+    grouping: 'Grouping',
+    resetFilters: 'Reset',
+    invalidDateRange: 'From date must be before to date.',
+    presets: {
+      thisMonth: 'This month',
+      lastMonth: 'Last month',
+      last3Months: 'Last 3 months',
+      last90Days: 'Last 90 days',
+      thisYear: 'This year',
+      ytd: 'Year to date',
+      lastYear: 'Last year',
+      custom: 'Custom',
+    },
+    groupings: {
+      adaptive: 'Adaptive',
+      daily: 'Daily',
+      weekly: 'Weekly',
+      monthly: 'Monthly',
+    },
+    categories: {
+      title: 'Categories',
+      income: 'Income categories',
+      expense: 'Expense categories',
+      uncategorizedIncome: 'Uncategorized income',
+      uncategorizedExpense: 'Uncategorized expense',
+    },
+    summary: {
+      income: 'Income',
+      expenses: 'Expenses',
+    },
+    charts: {
+      incomeExpenseTrend: 'Income-expense chart',
+      incomeStackedTrend: 'Income category trend',
+      expenseStackedTrend: 'Expense category trend',
+      incomeBreakdown: 'Income breakdown',
+      expenseBreakdown: 'Expense breakdown',
+      categoryTrendTable: 'Trend table',
+      empty: 'No data',
+    },
+    table: {
+      category: 'Category',
+      type: 'Type',
+      total: 'Total',
+      income: 'Income',
+      expense: 'Expense',
+    },
+  },
+};
+
+describe('AnalysisClient', () => {
+  let routerPush: ReturnType<typeof vi.fn>;
+
+  const accounts: Account[] = [
+    { id: 1, name: 'Checking Account', created_at: new Date('2026-01-01') },
+    { id: 2, name: 'Savings Account', created_at: new Date('2026-01-01') },
+  ];
+
+  const categories: CategoryWithPath[] = [
+    {
+      id: 10,
+      name: 'Salary',
+      parent_id: null,
+      category_type: 'income',
+      depth: 1,
+      created_at: new Date('2026-01-01'),
+      path: 'Salary',
+    },
+    {
+      id: 20,
+      name: 'Rent',
+      parent_id: null,
+      category_type: 'expense',
+      depth: 1,
+      created_at: new Date('2026-01-01'),
+      path: 'Rent',
+    },
+  ];
+
+  const filters: AnalysisFilters = {
+    preset: 'last-3-months',
+    from: '2026-02-10',
+    to: '2026-05-10',
+    grouping: 'adaptive',
+    resolvedGrouping: 'monthly',
+    includedCategoryIds: [],
+    hasCategoryFilter: false,
+    includeUncategorizedIncome: true,
+    includeUncategorizedExpense: true,
+    hasInvalidDateRange: false,
+  };
+
+  const data: TransactionAnalysisData = {
+    summary: { income: '5000.00', expenses: '2200.00' },
+    incomeExpenseTrend: [
+      { period: '2026-04', income: '5000.00', expenses: '2200.00' },
+    ],
+    incomeBreakdown: [],
+    expenseBreakdown: [],
+    incomeStackedTrend: [],
+    expenseStackedTrend: [],
+    categoryTrends: [],
+  };
+
+  beforeEach(() => {
+    Element.prototype.hasPointerCapture ??= vi.fn(() => false);
+    Element.prototype.setPointerCapture ??= vi.fn();
+    Element.prototype.releasePointerCapture ??= vi.fn();
+    Element.prototype.scrollIntoView ??= vi.fn();
+    routerPush = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({
+      push: routerPush,
+      replace: vi.fn(),
+      refresh: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      prefetch: vi.fn(),
+    } as ReturnType<typeof useRouter>);
+    vi.mocked(usePathname).mockReturnValue('/analysis');
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as ReturnType<typeof useSearchParams>
+    );
+  });
+
+  function renderClient(nextFilters: AnalysisFilters = filters) {
+    return render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AnalysisClient
+          accounts={accounts}
+          categories={categories}
+          filters={nextFilters}
+          data={data}
+          lang="en"
+        />
+      </NextIntlClientProvider>
+    );
+  }
+
+  async function selectOption(trigger: HTMLElement, name: string) {
+    const user = userEvent.setup();
+    await user.click(trigger);
+    await user.click(await screen.findByRole('option', { name }));
+  }
+
+  it('renders the page sections', () => {
+    renderClient();
+
+    expect(screen.getByRole('heading', { name: 'Analysis' })).toBeInTheDocument();
+    expect(screen.getByText('Explore income and expense trends.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Filters' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Income' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Expenses' })).toBeInTheDocument();
+    expect(screen.getByTestId('income-expense-chart')).toHaveTextContent(
+      'Income-expense chart'
+    );
+    expect(screen.getByTestId('trend-table')).toHaveTextContent('Trend table');
+  });
+
+  it('pushes the selected account into the URL while preserving lang', async () => {
+    renderClient();
+
+    const filtersCard = screen.getByRole('heading', { name: 'Filters' }).closest('div')
+      ?.parentElement;
+    expect(filtersCard).not.toBeNull();
+    const accountSelect = within(filtersCard as HTMLElement).getByRole('combobox', {
+      name: 'Account',
+    });
+
+    await selectOption(accountSelect, 'Savings Account');
+
+    const pushedUrl = routerPush.mock.calls.at(-1)?.[0] as string;
+    const pushedParams = new URLSearchParams(pushedUrl.split('?')[1]);
+    expect(pushedUrl.startsWith('/analysis?')).toBe(true);
+    expect(pushedParams.get('accountId')).toBe('2');
+    expect(pushedParams.get('lang')).toBe('en');
+  });
+
+  it('resets filters to the analysis page with lang', async () => {
+    const user = userEvent.setup();
+    renderClient({ ...filters, accountId: 1 });
+
+    await user.click(screen.getByRole('button', { name: 'Reset' }));
+
+    expect(routerPush).toHaveBeenCalledWith('/analysis?lang=en');
+  });
+});

--- a/__tests__/app/analysis-page.test.tsx
+++ b/__tests__/app/analysis-page.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AnalysisPage from '@/app/(dashboard)/analysis/page';
+import { getTransactionAnalysis } from '@/lib/analytics/transaction-analysis';
+import { getAllAccounts } from '@/lib/db/accounts';
+import { getAllCategoriesWithPaths } from '@/lib/db/categories';
+import { getLangFromUrl } from '@/lib/i18n/utils';
+import type { AnalysisFilterSearchParams } from '@/lib/analysis/filters';
+import type { TransactionAnalysisData } from '@/lib/analytics/transaction-analysis';
+import type { Account, CategoryWithPath } from '@/lib/db/types';
+
+vi.mock('@/app/(dashboard)/analysis/client', () => ({
+  AnalysisClient: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/analytics/transaction-analysis', () => ({
+  getTransactionAnalysis: vi.fn(),
+}));
+
+vi.mock('@/lib/db/accounts', () => ({
+  getAllAccounts: vi.fn(),
+}));
+
+vi.mock('@/lib/db/categories', () => ({
+  getAllCategoriesWithPaths: vi.fn(),
+}));
+
+vi.mock('@/lib/i18n/utils', () => ({
+  getLangFromUrl: vi.fn(),
+}));
+
+const accounts: Account[] = [
+  { id: 1, name: 'Checking', created_at: new Date('2026-01-01') },
+];
+
+const categories: CategoryWithPath[] = [
+  {
+    id: 7,
+    name: 'Rent',
+    parent_id: null,
+    category_type: 'expense',
+    depth: 1,
+    created_at: new Date('2026-01-01'),
+    path: 'Rent',
+  },
+];
+
+const data: TransactionAnalysisData = {
+  summary: { income: '0.00', expenses: '0.00' },
+  incomeExpenseTrend: [],
+  expenseBreakdown: [],
+  incomeBreakdown: [],
+  expenseStackedTrend: [],
+  incomeStackedTrend: [],
+  categoryTrends: [],
+};
+
+async function renderPage(searchParams: AnalysisFilterSearchParams) {
+  return AnalysisPage({ searchParams: Promise.resolve(searchParams) });
+}
+
+describe('AnalysisPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+    vi.clearAllMocks();
+    vi.mocked(getAllAccounts).mockResolvedValue(accounts);
+    vi.mocked(getAllCategoriesWithPaths).mockResolvedValue(categories);
+    vi.mocked(getLangFromUrl).mockResolvedValue('en');
+    vi.mocked(getTransactionAnalysis).mockResolvedValue(data);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('ignores invalid-only category filters instead of restricting analysis', async () => {
+    const page = await renderPage({ categories: '999999' });
+
+    expect(getTransactionAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasCategoryFilter: false,
+        includedCategoryIds: [],
+      })
+    );
+    expect(page).toEqual(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          filters: expect.objectContaining({
+            hasCategoryFilter: false,
+            includedCategoryIds: [],
+          }),
+        }),
+      })
+    );
+  });
+
+  it('keeps valid category IDs from mixed valid and invalid category filters', async () => {
+    await renderPage({ categories: '7,999999' });
+
+    expect(getTransactionAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasCategoryFilter: true,
+        includedCategoryIds: [7],
+      })
+    );
+  });
+
+  it('preserves an explicit empty category selection', async () => {
+    await renderPage({ categories: '' });
+
+    expect(getTransactionAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasCategoryFilter: true,
+        includedCategoryIds: [],
+      })
+    );
+  });
+});

--- a/__tests__/app/analysis-page.test.tsx
+++ b/__tests__/app/analysis-page.test.tsx
@@ -49,8 +49,8 @@ const data: TransactionAnalysisData = {
   incomeExpenseTrend: [],
   expenseBreakdown: [],
   incomeBreakdown: [],
-  expenseStackedTrend: [],
-  incomeStackedTrend: [],
+  expenseStackedTrend: { series: [], points: [] },
+  incomeStackedTrend: { series: [], points: [] },
   categoryTrends: [],
 };
 

--- a/__tests__/components/analysis/analysis-category-filter.test.tsx
+++ b/__tests__/components/analysis/analysis-category-filter.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { AnalysisCategoryFilter } from '@/components/analysis/analysis-category-filter';
+import type { CategoryWithPath } from '@/lib/db/types';
+
+const categories: CategoryWithPath[] = [
+  {
+    id: 1,
+    name: 'Revenue',
+    parent_id: null,
+    category_type: 'income',
+    depth: 1,
+    created_at: new Date('2026-01-01'),
+    path: 'Revenue',
+  },
+  {
+    id: 2,
+    name: 'Salary',
+    parent_id: 1,
+    category_type: 'income',
+    depth: 2,
+    created_at: new Date('2026-01-01'),
+    path: 'Revenue > Salary',
+  },
+  {
+    id: 3,
+    name: 'Bonus',
+    parent_id: 1,
+    category_type: 'income',
+    depth: 2,
+    created_at: new Date('2026-01-01'),
+    path: 'Revenue > Bonus',
+  },
+  {
+    id: 4,
+    name: 'Housing',
+    parent_id: null,
+    category_type: 'expense',
+    depth: 1,
+    created_at: new Date('2026-01-01'),
+    path: 'Housing',
+  },
+  {
+    id: 5,
+    name: 'Rent',
+    parent_id: 4,
+    category_type: 'expense',
+    depth: 2,
+    created_at: new Date('2026-01-01'),
+    path: 'Housing > Rent',
+  },
+];
+
+const labels = {
+  title: 'Categories',
+  income: 'Income',
+  expense: 'Expenses',
+  uncategorizedIncome: 'Uncategorized income',
+  uncategorizedExpense: 'Uncategorized expense',
+};
+
+describe('AnalysisCategoryFilter', () => {
+  it('selects a parent and all descendants together', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <AnalysisCategoryFilter
+        categories={categories}
+        selectedCategoryIds={[]}
+        includeUncategorizedIncome
+        includeUncategorizedExpense
+        labels={labels}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Revenue' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      selectedCategoryIds: [1, 2, 3],
+      includeUncategorizedIncome: true,
+      includeUncategorizedExpense: true,
+    });
+  });
+
+  it('lets a child override parent state after the parent toggles descendants', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    function ControlledFilter() {
+      const [selectedCategoryIds, setSelectedCategoryIds] = useState([1, 2, 3]);
+
+      return (
+        <AnalysisCategoryFilter
+          categories={categories}
+          selectedCategoryIds={selectedCategoryIds}
+          includeUncategorizedIncome
+          includeUncategorizedExpense
+          labels={labels}
+          onChange={(next) => {
+            setSelectedCategoryIds(next.selectedCategoryIds);
+            onChange(next);
+          }}
+        />
+      );
+    }
+
+    render(<ControlledFilter />);
+
+    await user.click(screen.getByRole('checkbox', { name: 'Bonus' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      selectedCategoryIds: [1, 2],
+      includeUncategorizedIncome: true,
+      includeUncategorizedExpense: true,
+    });
+    expect(screen.getByRole('checkbox', { name: 'Revenue' })).toHaveProperty(
+      'indeterminate',
+      true
+    );
+  });
+
+  it('toggles uncategorized income and expense independently', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <AnalysisCategoryFilter
+        categories={categories}
+        selectedCategoryIds={[1, 2, 3, 4, 5]}
+        includeUncategorizedIncome
+        includeUncategorizedExpense={false}
+        labels={labels}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Uncategorized income' })
+    );
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Uncategorized expense' })
+    );
+
+    expect(onChange).toHaveBeenNthCalledWith(1, {
+      selectedCategoryIds: [1, 2, 3, 4, 5],
+      includeUncategorizedIncome: false,
+      includeUncategorizedExpense: false,
+    });
+    expect(onChange).toHaveBeenNthCalledWith(2, {
+      selectedCategoryIds: [1, 2, 3, 4, 5],
+      includeUncategorizedIncome: true,
+      includeUncategorizedExpense: true,
+    });
+  });
+});

--- a/__tests__/lib/analysis/filters.test.ts
+++ b/__tests__/lib/analysis/filters.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  parseAnalysisFilters,
+  resolveAnalysisDateRange,
+  resolveAnalysisGrouping,
+} from '@/lib/analysis/filters';
+
+describe('analysis filters', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('parseAnalysisFilters', () => {
+    it('uses last-3-months defaults with all accounts, all categories, adaptive grouping, and uncategorized included', () => {
+      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+      const result = parseAnalysisFilters({});
+
+      expect(result).toEqual({
+        preset: 'last-3-months',
+        from: '2026-02-10',
+        to: '2026-05-10',
+        grouping: 'adaptive',
+        resolvedGrouping: 'weekly',
+        includedCategoryIds: [],
+        hasCategoryFilter: false,
+        includeUncategorizedIncome: true,
+        includeUncategorizedExpense: true,
+        hasInvalidDateRange: false,
+      });
+    });
+
+    it('parses a valid custom date range', () => {
+      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+      const result = parseAnalysisFilters({
+        preset: 'custom',
+        from: '2026-01-15',
+        to: '2026-04-20',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          preset: 'custom',
+          from: '2026-01-15',
+          to: '2026-04-20',
+          hasInvalidDateRange: false,
+        })
+      );
+    });
+
+    it('keeps reversed custom dates and marks the range invalid', () => {
+      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+      const result = parseAnalysisFilters({
+        preset: 'custom',
+        from: '2026-04-20',
+        to: '2026-01-15',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          preset: 'custom',
+          from: '2026-04-20',
+          to: '2026-01-15',
+          hasInvalidDateRange: true,
+        })
+      );
+    });
+
+    it('falls back from custom to last-3-months when a custom date is missing', () => {
+      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+      const result = parseAnalysisFilters({
+        preset: 'custom',
+        from: '2026-01-15',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          preset: 'last-3-months',
+          from: '2026-02-10',
+          to: '2026-05-10',
+          hasInvalidDateRange: false,
+        })
+      );
+    });
+
+    it('parses valid account, category, grouping, and uncategorized params', () => {
+      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+      const result = parseAnalysisFilters({
+        accountId: '4',
+        categories: ['7', '3', '7', '2'],
+        grouping: 'monthly',
+        uncategorizedIncome: 'false',
+        uncategorizedExpense: '0',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          accountId: 4,
+          grouping: 'monthly',
+          resolvedGrouping: 'monthly',
+          includedCategoryIds: [2, 3, 7],
+          hasCategoryFilter: true,
+          includeUncategorizedIncome: false,
+          includeUncategorizedExpense: false,
+        })
+      );
+    });
+
+    it('ignores malformed IDs and falls back from unknown grouping', () => {
+      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+      const result = parseAnalysisFilters({
+        accountId: '2abc',
+        categories: ['abc', '-1', '0', '2147483648', '1.5'],
+        grouping: 'yearly',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          grouping: 'adaptive',
+          resolvedGrouping: 'weekly',
+          includedCategoryIds: [],
+          hasCategoryFilter: true,
+        })
+      );
+      expect(result).not.toHaveProperty('accountId');
+    });
+
+    it('defaults malformed uncategorized params to included', () => {
+      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+      const result = parseAnalysisFilters({
+        uncategorizedIncome: 'no',
+        uncategorizedExpense: 'yes',
+      });
+
+      expect(result.includeUncategorizedIncome).toBe(true);
+      expect(result.includeUncategorizedExpense).toBe(true);
+    });
+  });
+
+  describe('resolveAnalysisDateRange', () => {
+    it('resolves this-month, last-month, and last-year presets in UTC', () => {
+      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+      expect(resolveAnalysisDateRange({ preset: 'this-month' })).toEqual({
+        preset: 'this-month',
+        from: '2026-05-01',
+        to: '2026-05-10',
+        hasInvalidDateRange: false,
+      });
+      expect(resolveAnalysisDateRange({ preset: 'last-month' })).toEqual({
+        preset: 'last-month',
+        from: '2026-04-01',
+        to: '2026-04-30',
+        hasInvalidDateRange: false,
+      });
+      expect(resolveAnalysisDateRange({ preset: 'last-year' })).toEqual({
+        preset: 'last-year',
+        from: '2025-01-01',
+        to: '2025-12-31',
+        hasInvalidDateRange: false,
+      });
+    });
+  });
+
+  describe('resolveAnalysisGrouping', () => {
+    it('resolves adaptive grouping by inclusive range length thresholds', () => {
+      expect(resolveAnalysisGrouping('adaptive', '2026-01-01', '2026-02-14')).toBe('daily');
+      expect(resolveAnalysisGrouping('adaptive', '2026-01-01', '2026-02-15')).toBe('weekly');
+      expect(resolveAnalysisGrouping('adaptive', '2026-01-01', '2026-06-29')).toBe('weekly');
+      expect(resolveAnalysisGrouping('adaptive', '2026-01-01', '2026-06-30')).toBe('monthly');
+    });
+
+    it('resolves explicit grouping to itself', () => {
+      expect(resolveAnalysisGrouping('daily', '2026-01-01', '2026-12-31')).toBe('daily');
+      expect(resolveAnalysisGrouping('weekly', '2026-01-01', '2026-01-02')).toBe('weekly');
+      expect(resolveAnalysisGrouping('monthly', '2026-01-01', '2026-01-02')).toBe('monthly');
+    });
+  });
+});

--- a/__tests__/lib/analytics/transaction-analysis.test.ts
+++ b/__tests__/lib/analytics/transaction-analysis.test.ts
@@ -96,26 +96,45 @@ describe('Transaction Analysis Analytics', () => {
 
       const result = groupStackedTrendRows(rows);
 
-      expect(result).toEqual([
-        {
-          period: '2025-01',
-          'Expense 1': '119.00',
-          'Expense 3': '117.00',
-          'Expense 5': '115.00',
-          'Expense 7': '113.00',
-          'Expense 9': '111.00',
-          Other: '109.00',
-        },
-        {
-          period: '2025-02',
-          'Expense 2': '118.00',
-          'Expense 4': '116.00',
-          'Expense 6': '114.00',
-          'Expense 8': '112.00',
-          'Expense 10': '110.00',
-          Other: '108.00',
-        },
-      ]);
+      expect(result).toEqual({
+        series: [
+          { key: 'expense-1', name: 'Expense 1' },
+          { key: 'expense-2', name: 'Expense 2' },
+          { key: 'expense-3', name: 'Expense 3' },
+          { key: 'expense-4', name: 'Expense 4' },
+          { key: 'expense-5', name: 'Expense 5' },
+          { key: 'expense-6', name: 'Expense 6' },
+          { key: 'expense-7', name: 'Expense 7' },
+          { key: 'expense-8', name: 'Expense 8' },
+          { key: 'expense-9', name: 'Expense 9' },
+          { key: 'expense-10', name: 'Expense 10' },
+          { key: 'other', name: 'Other' },
+        ],
+        points: [
+          {
+            period: '2025-01',
+            values: {
+              'expense-1': '119.00',
+              'expense-3': '117.00',
+              'expense-5': '115.00',
+              'expense-7': '113.00',
+              'expense-9': '111.00',
+              other: '109.00',
+            },
+          },
+          {
+            period: '2025-02',
+            values: {
+              'expense-2': '118.00',
+              'expense-4': '116.00',
+              'expense-6': '114.00',
+              'expense-8': '112.00',
+              'expense-10': '110.00',
+              other: '108.00',
+            },
+          },
+        ],
+      });
     });
 
     it('selects tied top categories deterministically by category path', () => {
@@ -140,22 +159,60 @@ describe('Transaction Analysis Analytics', () => {
 
       const result = groupStackedTrendRows(rows);
 
-      expect(result).toEqual([
+      expect(result).toEqual({
+        series: [
+          { key: 'expense-1', name: 'Category 01' },
+          { key: 'expense-2', name: 'Category 02' },
+          { key: 'expense-3', name: 'Category 03' },
+          { key: 'expense-4', name: 'Category 04' },
+          { key: 'expense-5', name: 'Category 05' },
+          { key: 'expense-6', name: 'Category 06' },
+          { key: 'expense-7', name: 'Category 07' },
+          { key: 'expense-8', name: 'Category 08' },
+          { key: 'expense-9', name: 'Category 09' },
+          { key: 'expense-10', name: 'Category 10' },
+          { key: 'other', name: 'Other' },
+        ],
+        points: [
+          {
+            period: '2025-01',
+            values: {
+              'expense-1': '100.00',
+              'expense-2': '100.00',
+              'expense-3': '100.00',
+              'expense-4': '100.00',
+              'expense-5': '100.00',
+              'expense-6': '100.00',
+              'expense-7': '100.00',
+              'expense-8': '100.00',
+              'expense-9': '100.00',
+              'expense-10': '100.00',
+              other: '100.00',
+            },
+          },
+        ],
+      });
+    });
+
+    it('uses stable series keys and display names for category paths', () => {
+      const result = groupStackedTrendRows([
         {
           period: '2025-01',
-          'Category 01': '100.00',
-          'Category 02': '100.00',
-          'Category 03': '100.00',
-          'Category 04': '100.00',
-          'Category 05': '100.00',
-          'Category 06': '100.00',
-          'Category 07': '100.00',
-          'Category 08': '100.00',
-          'Category 09': '100.00',
-          'Category 10': '100.00',
-          Other: '100.00',
+          category_key: 'expense-11',
+          category_path: 'Taxes > U.S. Federal',
+          amount: '250.00',
         },
       ]);
+
+      expect(result).toEqual({
+        series: [{ key: 'expense-11', name: 'Taxes > U.S. Federal' }],
+        points: [
+          {
+            period: '2025-01',
+            values: { 'expense-11': '250.00' },
+          },
+        ],
+      });
     });
   });
 
@@ -380,20 +437,31 @@ describe('Transaction Analysis Analytics', () => {
             percentage: 100,
           },
         ],
-        expenseStackedTrend: [
-          { period: '2025-01', 'Housing > Rent': '900.00' },
-          {
-            period: '2025-02',
-            'Housing > Rent': '100.00',
-            Uncategorized: '500.00',
-          },
-          { period: '2025-03' },
-        ],
-        incomeStackedTrend: [
-          { period: '2025-01', 'Work > Salary': '4000.00' },
-          { period: '2025-02', 'Work > Salary': '2000.00' },
-          { period: '2025-03' },
-        ],
+        expenseStackedTrend: {
+          series: [
+            { key: 'expense-2', name: 'Housing > Rent' },
+            { key: 'expense-uncategorized', name: 'Uncategorized' },
+          ],
+          points: [
+            { period: '2025-01', values: { 'expense-2': '900.00' } },
+            {
+              period: '2025-02',
+              values: {
+                'expense-2': '100.00',
+                'expense-uncategorized': '500.00',
+              },
+            },
+            { period: '2025-03', values: {} },
+          ],
+        },
+        incomeStackedTrend: {
+          series: [{ key: 'income-1', name: 'Work > Salary' }],
+          points: [
+            { period: '2025-01', values: { 'income-1': '4000.00' } },
+            { period: '2025-02', values: { 'income-1': '2000.00' } },
+            { period: '2025-03', values: {} },
+          ],
+        },
         categoryTrends: [
           {
             categoryKey: 'income-1',
@@ -528,16 +596,22 @@ describe('Transaction Analysis Analytics', () => {
         { period: '2025-02', income: '0.00', expenses: '0.00' },
         { period: '2025-03', income: '0.00', expenses: '0.00' },
       ]);
-      expect(result.expenseStackedTrend).toEqual([
-        { period: '2025-01', 'Housing > Rent': '500.00' },
-        { period: '2025-02' },
-        { period: '2025-03' },
-      ]);
-      expect(result.incomeStackedTrend).toEqual([
-        { period: '2025-01', 'Work > Salary': '1000.00' },
-        { period: '2025-02' },
-        { period: '2025-03' },
-      ]);
+      expect(result.expenseStackedTrend).toEqual({
+        series: [{ key: 'expense-2', name: 'Housing > Rent' }],
+        points: [
+          { period: '2025-01', values: { 'expense-2': '500.00' } },
+          { period: '2025-02', values: {} },
+          { period: '2025-03', values: {} },
+        ],
+      });
+      expect(result.incomeStackedTrend).toEqual({
+        series: [{ key: 'income-1', name: 'Work > Salary' }],
+        points: [
+          { period: '2025-01', values: { 'income-1': '1000.00' } },
+          { period: '2025-02', values: {} },
+          { period: '2025-03', values: {} },
+        ],
+      });
     });
   });
 });

--- a/__tests__/lib/analytics/transaction-analysis.test.ts
+++ b/__tests__/lib/analytics/transaction-analysis.test.ts
@@ -179,8 +179,6 @@ describe('Transaction Analysis Analytics', () => {
       const { queryMany, queryOne } = await import('@/lib/db');
       const filters: AnalysisFilters = {
         ...baseFilters,
-        grouping: 'weekly',
-        resolvedGrouping: 'weekly',
         accountId: 7,
         includedCategoryIds: [2, 5],
         hasCategoryFilter: true,
@@ -318,16 +316,16 @@ describe('Transaction Analysis Analytics', () => {
       }
 
       expect(queryManyCalls[0][0]).toContain(
-        "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
+        "TO_CHAR(DATE_TRUNC('month', t.date), 'YYYY-MM')"
       );
       expect(queryManyCalls[3][0]).toContain(
-        "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
+        "TO_CHAR(DATE_TRUNC('month', t.date), 'YYYY-MM')"
       );
       expect(queryManyCalls[4][0]).toContain(
-        "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
+        "TO_CHAR(DATE_TRUNC('month', t.date), 'YYYY-MM')"
       );
       expect(queryManyCalls[5][0]).toContain(
-        "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
+        "TO_CHAR(DATE_TRUNC('month', t.date), 'YYYY-MM')"
       );
 
       expect(queryManyCalls[1][0]).toContain("ch.category_type = 'expense'");
@@ -355,6 +353,7 @@ describe('Transaction Analysis Analytics', () => {
         incomeExpenseTrend: [
           { period: '2025-01', income: '4000.00', expenses: '900.00' },
           { period: '2025-02', income: '2000.00', expenses: '600.00' },
+          { period: '2025-03', income: '0.00', expenses: '0.00' },
         ],
         expenseBreakdown: [
           {
@@ -388,10 +387,12 @@ describe('Transaction Analysis Analytics', () => {
             'Housing > Rent': '100.00',
             Uncategorized: '500.00',
           },
+          { period: '2025-03' },
         ],
         incomeStackedTrend: [
           { period: '2025-01', 'Work > Salary': '4000.00' },
           { period: '2025-02', 'Work > Salary': '2000.00' },
+          { period: '2025-03' },
         ],
         categoryTrends: [
           {
@@ -485,6 +486,57 @@ describe('Transaction Analysis Analytics', () => {
             '2025-01': '100.00',
           },
         },
+      ]);
+    });
+
+    it('fills missing selected-range monthly buckets with zero trend values', async () => {
+      const { queryMany, queryOne } = await import('@/lib/db');
+
+      vi.mocked(queryOne).mockResolvedValue({
+        income: '1000.00',
+        expenses: '500.00',
+      });
+      vi.mocked(queryMany)
+        .mockResolvedValueOnce([
+          { period: '2025-01', income: '1000.00', expenses: '500.00' },
+          { period: '2025-03', income: '0.00', expenses: '0.00' },
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            period: '2025-01',
+            category_key: 'expense-2',
+            category_path: 'Housing > Rent',
+            amount: '500.00',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            period: '2025-01',
+            category_key: 'income-1',
+            category_path: 'Work > Salary',
+            amount: '1000.00',
+          },
+        ])
+        .mockResolvedValueOnce([]);
+
+      const result = await getTransactionAnalysis(baseFilters);
+
+      expect(result.incomeExpenseTrend).toEqual([
+        { period: '2025-01', income: '1000.00', expenses: '500.00' },
+        { period: '2025-02', income: '0.00', expenses: '0.00' },
+        { period: '2025-03', income: '0.00', expenses: '0.00' },
+      ]);
+      expect(result.expenseStackedTrend).toEqual([
+        { period: '2025-01', 'Housing > Rent': '500.00' },
+        { period: '2025-02' },
+        { period: '2025-03' },
+      ]);
+      expect(result.incomeStackedTrend).toEqual([
+        { period: '2025-01', 'Work > Salary': '1000.00' },
+        { period: '2025-02' },
+        { period: '2025-03' },
       ]);
     });
   });

--- a/__tests__/lib/analytics/transaction-analysis.test.ts
+++ b/__tests__/lib/analytics/transaction-analysis.test.ts
@@ -5,6 +5,7 @@ import {
   emptyTransactionAnalysis,
   getTransactionAnalysis,
   groupStackedTrendRows,
+  periodExpression,
 } from '@/lib/analytics/transaction-analysis';
 
 vi.mock('@/lib/db', () => ({
@@ -68,6 +69,18 @@ describe('Transaction Analysis Analytics', () => {
     });
   });
 
+  describe('periodExpression', () => {
+    it('returns the SQL expression for each supported grouping', () => {
+      expect(periodExpression('daily')).toBe("TO_CHAR(t.date, 'YYYY-MM-DD')");
+      expect(periodExpression('weekly')).toBe(
+        "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
+      );
+      expect(periodExpression('monthly')).toBe(
+        "TO_CHAR(DATE_TRUNC('month', t.date), 'YYYY-MM')"
+      );
+    });
+  });
+
   describe('groupStackedTrendRows', () => {
     it('keeps the top 10 full-range categories and folds the rest into Other', () => {
       const rows = Array.from({ length: 12 }, (_, index) => {
@@ -104,6 +117,46 @@ describe('Transaction Analysis Analytics', () => {
         },
       ]);
     });
+
+    it('selects tied top categories deterministically by category path', () => {
+      const rows = [
+        {
+          period: '2025-01',
+          category_key: 'expense-11',
+          category_path: 'Category 11',
+          amount: '100.00',
+        },
+        ...Array.from({ length: 10 }, (_, index) => {
+          const categoryNumber = index + 1;
+
+          return {
+            period: '2025-01',
+            category_key: `expense-${categoryNumber}`,
+            category_path: `Category ${String(categoryNumber).padStart(2, '0')}`,
+            amount: '100.00',
+          };
+        }),
+      ];
+
+      const result = groupStackedTrendRows(rows);
+
+      expect(result).toEqual([
+        {
+          period: '2025-01',
+          'Category 01': '100.00',
+          'Category 02': '100.00',
+          'Category 03': '100.00',
+          'Category 04': '100.00',
+          'Category 05': '100.00',
+          'Category 06': '100.00',
+          'Category 07': '100.00',
+          'Category 08': '100.00',
+          'Category 09': '100.00',
+          'Category 10': '100.00',
+          Other: '100.00',
+        },
+      ]);
+    });
   });
 
   describe('getTransactionAnalysis', () => {
@@ -124,6 +177,15 @@ describe('Transaction Analysis Analytics', () => {
 
     it('queries and shapes summary, trend, breakdown, stacked, and table rows', async () => {
       const { queryMany, queryOne } = await import('@/lib/db');
+      const filters: AnalysisFilters = {
+        ...baseFilters,
+        grouping: 'weekly',
+        resolvedGrouping: 'weekly',
+        accountId: 7,
+        includedCategoryIds: [2, 5],
+        hasCategoryFilter: true,
+      };
+      const expectedParams = ['2025-01-01', '2025-03-31', 7, [2, 5]];
 
       vi.mocked(queryOne).mockResolvedValue({
         income: '6000.00',
@@ -221,18 +283,55 @@ describe('Transaction Analysis Analytics', () => {
           },
         ]);
 
-      const result = await getTransactionAnalysis(baseFilters);
+      const result = await getTransactionAnalysis(filters);
 
       expect(queryOne).toHaveBeenCalledTimes(1);
       expect(queryMany).toHaveBeenCalledTimes(6);
-      expect(queryOne).toHaveBeenCalledWith(
-        expect.stringContaining('category_hierarchy'),
-        ['2025-01-01', '2025-03-31']
+      const allQueryCalls = [
+        vi.mocked(queryOne).mock.calls[0],
+        ...vi.mocked(queryMany).mock.calls,
+      ];
+
+      for (const [sql, params] of allQueryCalls) {
+        expect(sql).toContain('WITH RECURSIVE category_hierarchy');
+        expect(sql).toContain('t.date >= $1');
+        expect(sql).toContain('t.date <= $2');
+        expect(sql).toContain('t.account_id = $3');
+        expect(sql).toContain('t.category_id = ANY($4::int[])');
+        expect(sql).toContain('(t.category_id IS NULL AND t.amount > 0)');
+        expect(sql).toContain('(t.category_id IS NULL AND t.amount < 0)');
+        expect(params).toEqual(expectedParams);
+      }
+
+      const queryManyCalls = vi.mocked(queryMany).mock.calls;
+      expect(queryManyCalls[0][0]).toContain(
+        "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
       );
-      expect(queryMany).toHaveBeenNthCalledWith(
-        1,
-        expect.stringContaining("TO_CHAR(DATE_TRUNC('month', t.date), 'YYYY-MM')"),
-        ['2025-01-01', '2025-03-31']
+      expect(queryManyCalls[3][0]).toContain(
+        "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
+      );
+      expect(queryManyCalls[4][0]).toContain(
+        "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
+      );
+      expect(queryManyCalls[5][0]).toContain(
+        "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
+      );
+
+      expect(queryManyCalls[1][0]).toContain("ch.category_type = 'expense'");
+      expect(queryManyCalls[1][0]).toContain('(t.category_id IS NULL AND t.amount < 0)');
+      expect(queryManyCalls[2][0]).toContain("ch.category_type = 'income'");
+      expect(queryManyCalls[2][0]).toContain('(t.category_id IS NULL AND t.amount > 0)');
+      expect(queryManyCalls[3][0]).toContain("ch.category_type = 'expense'");
+      expect(queryManyCalls[3][0]).toContain('(t.category_id IS NULL AND t.amount < 0)');
+      expect(queryManyCalls[4][0]).toContain("ch.category_type = 'income'");
+      expect(queryManyCalls[4][0]).toContain('(t.category_id IS NULL AND t.amount > 0)');
+      expect(queryManyCalls[5][0]).toContain("WHEN ch.category_type = 'expense'");
+      expect(queryManyCalls[5][0]).toContain("WHEN ch.category_type = 'income'");
+      expect(queryManyCalls[5][0]).toContain(
+        "WHEN t.category_id IS NULL AND t.amount < 0 THEN 'expense'"
+      );
+      expect(queryManyCalls[5][0]).toContain(
+        "WHEN t.category_id IS NULL AND t.amount > 0 THEN 'income'"
       );
 
       expect(result).toEqual({
@@ -304,6 +403,76 @@ describe('Transaction Analysis Analytics', () => {
           },
         ],
       });
+    });
+
+    it('sorts category trend rows with equal totals by category path then key', async () => {
+      const { queryMany, queryOne } = await import('@/lib/db');
+
+      vi.mocked(queryOne).mockResolvedValue({
+        income: '0.00',
+        expenses: '0.00',
+      });
+      vi.mocked(queryMany)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            period: '2025-01',
+            category_key: 'expense-3',
+            category_type: 'expense',
+            category_path: 'Category B',
+            amount: '100.00',
+          },
+          {
+            period: '2025-01',
+            category_key: 'expense-2',
+            category_type: 'expense',
+            category_path: 'Category A',
+            amount: '100.00',
+          },
+          {
+            period: '2025-01',
+            category_key: 'expense-1',
+            category_type: 'expense',
+            category_path: 'Category A',
+            amount: '100.00',
+          },
+        ]);
+
+      const result = await getTransactionAnalysis(baseFilters);
+
+      expect(result.categoryTrends).toEqual([
+        {
+          categoryKey: 'expense-1',
+          categoryType: 'expense',
+          categoryPath: 'Category A',
+          total: '100.00',
+          periods: {
+            '2025-01': '100.00',
+          },
+        },
+        {
+          categoryKey: 'expense-2',
+          categoryType: 'expense',
+          categoryPath: 'Category A',
+          total: '100.00',
+          periods: {
+            '2025-01': '100.00',
+          },
+        },
+        {
+          categoryKey: 'expense-3',
+          categoryType: 'expense',
+          categoryPath: 'Category B',
+          total: '100.00',
+          periods: {
+            '2025-01': '100.00',
+          },
+        },
+      ]);
     });
   });
 });

--- a/__tests__/lib/analytics/transaction-analysis.test.ts
+++ b/__tests__/lib/analytics/transaction-analysis.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AnalysisFilters } from '@/lib/analysis/filters';
+import {
+  buildAnalysisWhereClause,
+  emptyTransactionAnalysis,
+  getTransactionAnalysis,
+  groupStackedTrendRows,
+} from '@/lib/analytics/transaction-analysis';
+
+vi.mock('@/lib/db', () => ({
+  queryMany: vi.fn(),
+  queryOne: vi.fn(),
+}));
+
+const baseFilters: AnalysisFilters = {
+  preset: 'custom',
+  from: '2025-01-01',
+  to: '2025-03-31',
+  grouping: 'monthly',
+  resolvedGrouping: 'monthly',
+  includedCategoryIds: [],
+  hasCategoryFilter: false,
+  includeUncategorizedIncome: true,
+  includeUncategorizedExpense: true,
+  hasInvalidDateRange: false,
+};
+
+describe('Transaction Analysis Analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('buildAnalysisWhereClause', () => {
+    it('parameterizes date, account, category ids, and uncategorized category filters', () => {
+      const result = buildAnalysisWhereClause({
+        ...baseFilters,
+        accountId: 7,
+        includedCategoryIds: [2, 5],
+        hasCategoryFilter: true,
+        includeUncategorizedIncome: true,
+        includeUncategorizedExpense: false,
+      });
+
+      expect(result.params).toEqual([
+        '2025-01-01',
+        '2025-03-31',
+        7,
+        [2, 5],
+      ]);
+      expect(result.whereClause).toContain('t.date >= $1');
+      expect(result.whereClause).toContain('t.date <= $2');
+      expect(result.whereClause).toContain('t.account_id = $3');
+      expect(result.whereClause).toContain('t.category_id = ANY($4::int[])');
+      expect(result.whereClause).toContain('(t.category_id IS NULL AND t.amount > 0)');
+      expect(result.whereClause).not.toContain('(t.category_id IS NULL AND t.amount < 0)');
+    });
+
+    it('uses FALSE when category filter excludes all categories and uncategorized transactions', () => {
+      const result = buildAnalysisWhereClause({
+        ...baseFilters,
+        hasCategoryFilter: true,
+        includeUncategorizedIncome: false,
+        includeUncategorizedExpense: false,
+      });
+
+      expect(result.params).toEqual(['2025-01-01', '2025-03-31']);
+      expect(result.whereClause).toContain('AND (FALSE)');
+    });
+  });
+
+  describe('groupStackedTrendRows', () => {
+    it('keeps the top 10 full-range categories and folds the rest into Other', () => {
+      const rows = Array.from({ length: 12 }, (_, index) => {
+        const categoryNumber = index + 1;
+
+        return {
+          period: index % 2 === 0 ? '2025-01' : '2025-02',
+          category_key: `expense-${categoryNumber}`,
+          category_path: `Expense ${categoryNumber}`,
+          amount: `${120 - categoryNumber}.00`,
+        };
+      });
+
+      const result = groupStackedTrendRows(rows);
+
+      expect(result).toEqual([
+        {
+          period: '2025-01',
+          'Expense 1': '119.00',
+          'Expense 3': '117.00',
+          'Expense 5': '115.00',
+          'Expense 7': '113.00',
+          'Expense 9': '111.00',
+          Other: '109.00',
+        },
+        {
+          period: '2025-02',
+          'Expense 2': '118.00',
+          'Expense 4': '116.00',
+          'Expense 6': '114.00',
+          'Expense 8': '112.00',
+          'Expense 10': '110.00',
+          Other: '108.00',
+        },
+      ]);
+    });
+  });
+
+  describe('getTransactionAnalysis', () => {
+    it('returns empty analysis without querying when the date range is invalid', async () => {
+      const { queryMany, queryOne } = await import('@/lib/db');
+
+      const result = await getTransactionAnalysis({
+        ...baseFilters,
+        from: '2025-03-31',
+        to: '2025-01-01',
+        hasInvalidDateRange: true,
+      });
+
+      expect(result).toEqual(emptyTransactionAnalysis());
+      expect(queryOne).not.toHaveBeenCalled();
+      expect(queryMany).not.toHaveBeenCalled();
+    });
+
+    it('queries and shapes summary, trend, breakdown, stacked, and table rows', async () => {
+      const { queryMany, queryOne } = await import('@/lib/db');
+
+      vi.mocked(queryOne).mockResolvedValue({
+        income: '6000.00',
+        expenses: '1500.00',
+      });
+      vi.mocked(queryMany)
+        .mockResolvedValueOnce([
+          { period: '2025-01', income: '4000.00', expenses: '900.00' },
+          { period: '2025-02', income: '2000.00', expenses: '600.00' },
+        ])
+        .mockResolvedValueOnce([
+          {
+            category_id: 2,
+            category_name: 'Rent',
+            category_path: 'Housing > Rent',
+            amount: '1000.00',
+          },
+          {
+            category_id: null,
+            category_name: 'Uncategorized',
+            category_path: 'Uncategorized',
+            amount: '500.00',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            category_id: 1,
+            category_name: 'Salary',
+            category_path: 'Work > Salary',
+            amount: '6000.00',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            period: '2025-01',
+            category_key: 'expense-2',
+            category_path: 'Housing > Rent',
+            amount: '900.00',
+          },
+          {
+            period: '2025-02',
+            category_key: 'expense-2',
+            category_path: 'Housing > Rent',
+            amount: '100.00',
+          },
+          {
+            period: '2025-02',
+            category_key: 'expense-uncategorized',
+            category_path: 'Uncategorized',
+            amount: '500.00',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            period: '2025-01',
+            category_key: 'income-1',
+            category_path: 'Work > Salary',
+            amount: '4000.00',
+          },
+          {
+            period: '2025-02',
+            category_key: 'income-1',
+            category_path: 'Work > Salary',
+            amount: '2000.00',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            period: '2025-01',
+            category_key: 'income-1',
+            category_type: 'income',
+            category_path: 'Work > Salary',
+            amount: '4000.00',
+          },
+          {
+            period: '2025-02',
+            category_key: 'income-1',
+            category_type: 'income',
+            category_path: 'Work > Salary',
+            amount: '2000.00',
+          },
+          {
+            period: '2025-01',
+            category_key: 'expense-2',
+            category_type: 'expense',
+            category_path: 'Housing > Rent',
+            amount: '900.00',
+          },
+          {
+            period: '2025-02',
+            category_key: 'expense-2',
+            category_type: 'expense',
+            category_path: 'Housing > Rent',
+            amount: '100.00',
+          },
+        ]);
+
+      const result = await getTransactionAnalysis(baseFilters);
+
+      expect(queryOne).toHaveBeenCalledTimes(1);
+      expect(queryMany).toHaveBeenCalledTimes(6);
+      expect(queryOne).toHaveBeenCalledWith(
+        expect.stringContaining('category_hierarchy'),
+        ['2025-01-01', '2025-03-31']
+      );
+      expect(queryMany).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining("TO_CHAR(DATE_TRUNC('month', t.date), 'YYYY-MM')"),
+        ['2025-01-01', '2025-03-31']
+      );
+
+      expect(result).toEqual({
+        summary: {
+          income: '6000.00',
+          expenses: '1500.00',
+        },
+        incomeExpenseTrend: [
+          { period: '2025-01', income: '4000.00', expenses: '900.00' },
+          { period: '2025-02', income: '2000.00', expenses: '600.00' },
+        ],
+        expenseBreakdown: [
+          {
+            category_id: 2,
+            category_name: 'Rent',
+            category_path: 'Housing > Rent',
+            amount: '1000.00',
+            percentage: 66.66666666666666,
+          },
+          {
+            category_id: null,
+            category_name: 'Uncategorized',
+            category_path: 'Uncategorized',
+            amount: '500.00',
+            percentage: 33.33333333333333,
+          },
+        ],
+        incomeBreakdown: [
+          {
+            category_id: 1,
+            category_name: 'Salary',
+            category_path: 'Work > Salary',
+            amount: '6000.00',
+            percentage: 100,
+          },
+        ],
+        expenseStackedTrend: [
+          { period: '2025-01', 'Housing > Rent': '900.00' },
+          {
+            period: '2025-02',
+            'Housing > Rent': '100.00',
+            Uncategorized: '500.00',
+          },
+        ],
+        incomeStackedTrend: [
+          { period: '2025-01', 'Work > Salary': '4000.00' },
+          { period: '2025-02', 'Work > Salary': '2000.00' },
+        ],
+        categoryTrends: [
+          {
+            categoryKey: 'income-1',
+            categoryType: 'income',
+            categoryPath: 'Work > Salary',
+            total: '6000.00',
+            periods: {
+              '2025-01': '4000.00',
+              '2025-02': '2000.00',
+            },
+          },
+          {
+            categoryKey: 'expense-2',
+            categoryType: 'expense',
+            categoryPath: 'Housing > Rent',
+            total: '1000.00',
+            periods: {
+              '2025-01': '900.00',
+              '2025-02': '100.00',
+            },
+          },
+        ],
+      });
+    });
+  });
+});

--- a/__tests__/lib/analytics/transaction-analysis.test.ts
+++ b/__tests__/lib/analytics/transaction-analysis.test.ts
@@ -304,6 +304,19 @@ describe('Transaction Analysis Analytics', () => {
       }
 
       const queryManyCalls = vi.mocked(queryMany).mock.calls;
+      const summarySql = vi.mocked(queryOne).mock.calls[0][0];
+      const incomeExpenseTrendSql = queryManyCalls[0][0];
+      const incomeExpenseClassificationSql = [summarySql, incomeExpenseTrendSql];
+
+      for (const sql of incomeExpenseClassificationSql) {
+        expect(sql).toContain("WHEN ch.category_type = 'income' THEN t.amount");
+        expect(sql).toContain("WHEN ch.category_type = 'expense' THEN ABS(t.amount)");
+        expect(sql).toContain('WHEN t.category_id IS NULL AND t.amount > 0 THEN t.amount');
+        expect(sql).toContain(
+          'WHEN t.category_id IS NULL AND t.amount < 0 THEN ABS(t.amount)'
+        );
+      }
+
       expect(queryManyCalls[0][0]).toContain(
         "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')"
       );

--- a/__tests__/lib/analytics/transaction-analysis.test.ts
+++ b/__tests__/lib/analytics/transaction-analysis.test.ts
@@ -401,6 +401,7 @@ describe('Transaction Analysis Analytics', () => {
       expect(queryManyCalls[5][0]).toContain(
         "WHEN t.category_id IS NULL AND t.amount > 0 THEN 'income'"
       );
+      expect(queryManyCalls[5][0]).toContain('FROM categorized_transactions');
 
       expect(result).toEqual({
         summary: {

--- a/app/(dashboard)/analysis/client.tsx
+++ b/app/(dashboard)/analysis/client.tsx
@@ -1,0 +1,329 @@
+'use client';
+
+import { useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { AnalysisCategoryFilter } from '@/components/analysis/analysis-category-filter';
+import { AnalysisSummaryCards } from '@/components/analysis/analysis-summary-cards';
+import { CategoryBreakdownChart } from '@/components/analysis/category-breakdown-chart';
+import { CategoryStackedTrendChart } from '@/components/analysis/category-stacked-trend-chart';
+import { CategoryTrendTable } from '@/components/analysis/category-trend-table';
+import { IncomeExpenseTrendChart } from '@/components/analysis/income-expense-trend-chart';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type {
+  AnalysisDatePreset,
+  AnalysisFilters,
+  AnalysisGrouping,
+} from '@/lib/analysis/filters';
+import type { TransactionAnalysisData } from '@/lib/analytics/transaction-analysis';
+import type { Account, CategoryWithPath } from '@/lib/db/types';
+
+interface AnalysisClientProps {
+  accounts: Account[];
+  categories: CategoryWithPath[];
+  filters: AnalysisFilters;
+  data: TransactionAnalysisData;
+  lang: string;
+}
+
+const DATE_PRESET_OPTIONS: Array<{
+  value: AnalysisDatePreset;
+  labelKey: string;
+}> = [
+  { value: 'this-month', labelKey: 'presets.thisMonth' },
+  { value: 'last-month', labelKey: 'presets.lastMonth' },
+  { value: 'last-3-months', labelKey: 'presets.last3Months' },
+  { value: 'last-90-days', labelKey: 'presets.last90Days' },
+  { value: 'this-year', labelKey: 'presets.thisYear' },
+  { value: 'ytd', labelKey: 'presets.ytd' },
+  { value: 'last-year', labelKey: 'presets.lastYear' },
+  { value: 'custom', labelKey: 'presets.custom' },
+];
+
+const GROUPING_OPTIONS: Array<{
+  value: AnalysisGrouping;
+  labelKey: string;
+}> = [
+  { value: 'adaptive', labelKey: 'groupings.adaptive' },
+  { value: 'daily', labelKey: 'groupings.daily' },
+  { value: 'weekly', labelKey: 'groupings.weekly' },
+  { value: 'monthly', labelKey: 'groupings.monthly' },
+];
+
+function setOptionalParam(params: URLSearchParams, key: string, value: string) {
+  if (value) {
+    params.set(key, value);
+  } else {
+    params.delete(key);
+  }
+}
+
+export function AnalysisClient({
+  accounts,
+  categories,
+  filters,
+  data,
+  lang,
+}: AnalysisClientProps) {
+  const t = useTranslations('analysis');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const selectedCategoryIds = filters.hasCategoryFilter
+    ? filters.includedCategoryIds
+    : categories.map((category) => category.id);
+  const periods = useMemo(
+    () => [
+      ...new Set(data.incomeExpenseTrend.map((point) => point.period)),
+    ],
+    [data.incomeExpenseTrend]
+  );
+
+  const pushParams = (update: (params: URLSearchParams) => void) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (!params.get('lang')) {
+      params.set('lang', lang);
+    }
+
+    update(params);
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  const updateFilter = (key: string, value: string) => {
+    pushParams((params) => setOptionalParam(params, key, value));
+  };
+
+  const updateDateFilter = (key: 'from' | 'to', value: string) => {
+    pushParams((params) => {
+      params.set('preset', 'custom');
+      setOptionalParam(params, key, value);
+    });
+  };
+
+  const resetFilters = () => {
+    router.push(`/analysis?lang=${encodeURIComponent(lang)}`);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-3xl font-bold">{t('title')}</h2>
+        <p className="text-muted-foreground">{t('description')}</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('filters')}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
+            <div className="space-y-2">
+              <Label htmlFor="analysis-preset">{t('dateRangePreset')}</Label>
+              <Select
+                value={filters.preset}
+                onValueChange={(value) => updateFilter('preset', value)}
+              >
+                <SelectTrigger
+                  id="analysis-preset"
+                  aria-label={t('dateRangePreset')}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DATE_PRESET_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {t(option.labelKey)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="analysis-from">{t('from')}</Label>
+              <Input
+                id="analysis-from"
+                type="date"
+                value={filters.from}
+                onChange={(event) => updateDateFilter('from', event.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="analysis-to">{t('to')}</Label>
+              <Input
+                id="analysis-to"
+                type="date"
+                value={filters.to}
+                onChange={(event) => updateDateFilter('to', event.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="analysis-account">{t('account')}</Label>
+              <Select
+                value={filters.accountId?.toString() ?? 'all'}
+                onValueChange={(value) =>
+                  updateFilter('accountId', value === 'all' ? '' : value)
+                }
+              >
+                <SelectTrigger id="analysis-account" aria-label={t('account')}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t('allAccounts')}</SelectItem>
+                  {accounts.map((account) => (
+                    <SelectItem key={account.id} value={account.id.toString()}>
+                      {account.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="analysis-grouping">{t('grouping')}</Label>
+              <Select
+                value={filters.grouping}
+                onValueChange={(value) => updateFilter('grouping', value)}
+              >
+                <SelectTrigger id="analysis-grouping" aria-label={t('grouping')}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {GROUPING_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {t(option.labelKey)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex justify-end">
+            <Button type="button" variant="outline" onClick={resetFilters}>
+              {t('resetFilters')}
+            </Button>
+          </div>
+
+          {filters.hasInvalidDateRange ? (
+            <div className="text-sm font-medium text-red-600" role="alert">
+              {t('invalidDateRange')}
+            </div>
+          ) : null}
+
+          <AnalysisCategoryFilter
+            categories={categories}
+            selectedCategoryIds={selectedCategoryIds}
+            includeUncategorizedIncome={filters.includeUncategorizedIncome}
+            includeUncategorizedExpense={filters.includeUncategorizedExpense}
+            labels={{
+              title: t('categories.title'),
+              income: t('categories.income'),
+              expense: t('categories.expense'),
+              uncategorizedIncome: t('categories.uncategorizedIncome'),
+              uncategorizedExpense: t('categories.uncategorizedExpense'),
+            }}
+            onChange={(next) => {
+              pushParams((params) => {
+                params.set('categories', next.selectedCategoryIds.join(','));
+
+                if (next.includeUncategorizedIncome) {
+                  params.delete('uncategorizedIncome');
+                } else {
+                  params.set('uncategorizedIncome', '0');
+                }
+
+                if (next.includeUncategorizedExpense) {
+                  params.delete('uncategorizedExpense');
+                } else {
+                  params.set('uncategorizedExpense', '0');
+                }
+              });
+            }}
+          />
+        </CardContent>
+      </Card>
+
+      <AnalysisSummaryCards
+        income={data.summary.income}
+        expenses={data.summary.expenses}
+        locale={lang}
+        labels={{
+          income: t('summary.income'),
+          expenses: t('summary.expenses'),
+        }}
+      />
+
+      <IncomeExpenseTrendChart
+        data={data.incomeExpenseTrend}
+        title={t('charts.incomeExpenseTrend')}
+        emptyText={t('charts.empty')}
+        locale={lang}
+        labels={{
+          income: t('summary.income'),
+          expenses: t('summary.expenses'),
+        }}
+      />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <CategoryStackedTrendChart
+          data={data.incomeStackedTrend}
+          title={t('charts.incomeStackedTrend')}
+          emptyText={t('charts.empty')}
+          locale={lang}
+        />
+        <CategoryStackedTrendChart
+          data={data.expenseStackedTrend}
+          title={t('charts.expenseStackedTrend')}
+          emptyText={t('charts.empty')}
+          locale={lang}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <CategoryBreakdownChart
+          data={data.incomeBreakdown}
+          title={t('charts.incomeBreakdown')}
+          emptyText={t('charts.empty')}
+          color="#22c55e"
+          locale={lang}
+        />
+        <CategoryBreakdownChart
+          data={data.expenseBreakdown}
+          title={t('charts.expenseBreakdown')}
+          emptyText={t('charts.empty')}
+          color="#ef4444"
+          locale={lang}
+        />
+      </div>
+
+      <CategoryTrendTable
+        rows={data.categoryTrends}
+        periods={periods}
+        title={t('charts.categoryTrendTable')}
+        emptyText={t('charts.empty')}
+        locale={lang}
+        labels={{
+          category: t('table.category'),
+          type: t('table.type'),
+          total: t('table.total'),
+          income: t('table.income'),
+          expense: t('table.expense'),
+        }}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/analysis/client.tsx
+++ b/app/(dashboard)/analysis/client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { AnalysisCategoryFilter } from '@/components/analysis/analysis-category-filter';
@@ -36,6 +36,17 @@ interface AnalysisClientProps {
   lang: string;
 }
 
+interface AnalysisFilterDraft {
+  preset: AnalysisDatePreset;
+  from: string;
+  to: string;
+  accountId: string;
+  grouping: AnalysisGrouping;
+  categoryIds: number[];
+  includeUncategorizedIncome: boolean;
+  includeUncategorizedExpense: boolean;
+}
+
 const DATE_PRESET_OPTIONS: Array<{
   value: AnalysisDatePreset;
   labelKey: string;
@@ -60,12 +71,26 @@ const GROUPING_OPTIONS: Array<{
   { value: 'monthly', labelKey: 'groupings.monthly' },
 ];
 
-function setOptionalParam(params: URLSearchParams, key: string, value: string) {
-  if (value) {
-    params.set(key, value);
-  } else {
-    params.delete(key);
-  }
+function sortedCategoryIds(ids: Iterable<number>) {
+  return [...ids].sort((a, b) => a - b);
+}
+
+function createAnalysisFilterDraft(
+  filters: AnalysisFilters,
+  categories: CategoryWithPath[]
+): AnalysisFilterDraft {
+  return {
+    preset: filters.preset,
+    from: filters.from,
+    to: filters.to,
+    accountId: filters.accountId?.toString() ?? '',
+    grouping: filters.grouping,
+    categoryIds: filters.hasCategoryFilter
+      ? sortedCategoryIds(filters.includedCategoryIds)
+      : sortedCategoryIds(categories.map((category) => category.id)),
+    includeUncategorizedIncome: filters.includeUncategorizedIncome,
+    includeUncategorizedExpense: filters.includeUncategorizedExpense,
+  };
 }
 
 export function AnalysisClient({
@@ -79,9 +104,14 @@ export function AnalysisClient({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const selectedCategoryIds = filters.hasCategoryFilter
-    ? filters.includedCategoryIds
-    : categories.map((category) => category.id);
+  const [filterDraft, setFilterDraft] = useState(() =>
+    createAnalysisFilterDraft(filters, categories)
+  );
+  const filterDraftRef = useRef(filterDraft);
+  const allCategoryIds = useMemo(
+    () => sortedCategoryIds(categories.map((category) => category.id)),
+    [categories]
+  );
   const periods = useMemo(
     () => [
       ...new Set(data.incomeExpenseTrend.map((point) => point.period)),
@@ -89,26 +119,84 @@ export function AnalysisClient({
     [data.incomeExpenseTrend]
   );
 
-  const pushParams = (update: (params: URLSearchParams) => void) => {
+  const pushDraft = (draft: AnalysisFilterDraft) => {
     const params = new URLSearchParams(searchParams.toString());
 
-    if (!params.get('lang')) {
-      params.set('lang', lang);
+    params.set('lang', lang);
+
+    if (draft.preset === 'last-3-months') {
+      params.delete('preset');
+    } else {
+      params.set('preset', draft.preset);
     }
 
-    update(params);
+    if (draft.preset === 'custom') {
+      params.set('from', draft.from);
+      params.set('to', draft.to);
+    } else {
+      params.delete('from');
+      params.delete('to');
+    }
+
+    if (draft.accountId) {
+      params.set('accountId', draft.accountId);
+    } else {
+      params.delete('accountId');
+    }
+
+    if (draft.grouping === 'adaptive') {
+      params.delete('grouping');
+    } else {
+      params.set('grouping', draft.grouping);
+    }
+
+    const selectedCategoryIds = sortedCategoryIds(draft.categoryIds);
+    const allCategoriesSelected =
+      selectedCategoryIds.length === allCategoryIds.length &&
+      selectedCategoryIds.every((id, index) => id === allCategoryIds[index]);
+    const hasDefaultCategoryFilter =
+      allCategoriesSelected &&
+      draft.includeUncategorizedIncome &&
+      draft.includeUncategorizedExpense;
+
+    if (hasDefaultCategoryFilter) {
+      params.delete('categories');
+      params.delete('uncategorizedIncome');
+      params.delete('uncategorizedExpense');
+    } else {
+      params.set('categories', selectedCategoryIds.join(','));
+
+      if (draft.includeUncategorizedIncome) {
+        params.delete('uncategorizedIncome');
+      } else {
+        params.set('uncategorizedIncome', '0');
+      }
+
+      if (draft.includeUncategorizedExpense) {
+        params.delete('uncategorizedExpense');
+      } else {
+        params.set('uncategorizedExpense', '0');
+      }
+    }
+
     router.push(`${pathname}?${params.toString()}`);
   };
 
-  const updateFilter = (key: string, value: string) => {
-    pushParams((params) => setOptionalParam(params, key, value));
+  const updateDraft = (
+    update: (current: AnalysisFilterDraft) => AnalysisFilterDraft
+  ) => {
+    const nextDraft = update(filterDraftRef.current);
+    filterDraftRef.current = nextDraft;
+    setFilterDraft(nextDraft);
+    pushDraft(nextDraft);
   };
 
   const updateDateFilter = (key: 'from' | 'to', value: string) => {
-    pushParams((params) => {
-      params.set('preset', 'custom');
-      setOptionalParam(params, key, value);
-    });
+    updateDraft((current) => ({
+      ...current,
+      preset: 'custom',
+      [key]: value,
+    }));
   };
 
   const resetFilters = () => {
@@ -131,8 +219,13 @@ export function AnalysisClient({
             <div className="space-y-2">
               <Label htmlFor="analysis-preset">{t('dateRangePreset')}</Label>
               <Select
-                value={filters.preset}
-                onValueChange={(value) => updateFilter('preset', value)}
+                value={filterDraft.preset}
+                onValueChange={(value) =>
+                  updateDraft((current) => ({
+                    ...current,
+                    preset: value as AnalysisDatePreset,
+                  }))
+                }
               >
                 <SelectTrigger
                   id="analysis-preset"
@@ -155,7 +248,7 @@ export function AnalysisClient({
               <Input
                 id="analysis-from"
                 type="date"
-                value={filters.from}
+                value={filterDraft.from}
                 onChange={(event) => updateDateFilter('from', event.target.value)}
               />
             </div>
@@ -165,7 +258,7 @@ export function AnalysisClient({
               <Input
                 id="analysis-to"
                 type="date"
-                value={filters.to}
+                value={filterDraft.to}
                 onChange={(event) => updateDateFilter('to', event.target.value)}
               />
             </div>
@@ -173,9 +266,12 @@ export function AnalysisClient({
             <div className="space-y-2">
               <Label htmlFor="analysis-account">{t('account')}</Label>
               <Select
-                value={filters.accountId?.toString() ?? 'all'}
+                value={filterDraft.accountId || 'all'}
                 onValueChange={(value) =>
-                  updateFilter('accountId', value === 'all' ? '' : value)
+                  updateDraft((current) => ({
+                    ...current,
+                    accountId: value === 'all' ? '' : value,
+                  }))
                 }
               >
                 <SelectTrigger id="analysis-account" aria-label={t('account')}>
@@ -195,8 +291,13 @@ export function AnalysisClient({
             <div className="space-y-2">
               <Label htmlFor="analysis-grouping">{t('grouping')}</Label>
               <Select
-                value={filters.grouping}
-                onValueChange={(value) => updateFilter('grouping', value)}
+                value={filterDraft.grouping}
+                onValueChange={(value) =>
+                  updateDraft((current) => ({
+                    ...current,
+                    grouping: value as AnalysisGrouping,
+                  }))
+                }
               >
                 <SelectTrigger id="analysis-grouping" aria-label={t('grouping')}>
                   <SelectValue />
@@ -226,9 +327,9 @@ export function AnalysisClient({
 
           <AnalysisCategoryFilter
             categories={categories}
-            selectedCategoryIds={selectedCategoryIds}
-            includeUncategorizedIncome={filters.includeUncategorizedIncome}
-            includeUncategorizedExpense={filters.includeUncategorizedExpense}
+            selectedCategoryIds={filterDraft.categoryIds}
+            includeUncategorizedIncome={filterDraft.includeUncategorizedIncome}
+            includeUncategorizedExpense={filterDraft.includeUncategorizedExpense}
             labels={{
               title: t('categories.title'),
               income: t('categories.income'),
@@ -237,21 +338,12 @@ export function AnalysisClient({
               uncategorizedExpense: t('categories.uncategorizedExpense'),
             }}
             onChange={(next) => {
-              pushParams((params) => {
-                params.set('categories', next.selectedCategoryIds.join(','));
-
-                if (next.includeUncategorizedIncome) {
-                  params.delete('uncategorizedIncome');
-                } else {
-                  params.set('uncategorizedIncome', '0');
-                }
-
-                if (next.includeUncategorizedExpense) {
-                  params.delete('uncategorizedExpense');
-                } else {
-                  params.set('uncategorizedExpense', '0');
-                }
-              });
+              updateDraft((current) => ({
+                ...current,
+                categoryIds: sortedCategoryIds(next.selectedCategoryIds),
+                includeUncategorizedIncome: next.includeUncategorizedIncome,
+                includeUncategorizedExpense: next.includeUncategorizedExpense,
+              }));
             }}
           />
         </CardContent>

--- a/app/(dashboard)/analysis/client.tsx
+++ b/app/(dashboard)/analysis/client.tsx
@@ -93,6 +93,25 @@ function createAnalysisFilterDraft(
   };
 }
 
+function createAnalysisFilterDraftSyncKey(
+  filters: AnalysisFilters,
+  categories: CategoryWithPath[]
+) {
+  return [
+    filters.preset,
+    filters.from,
+    filters.to,
+    filters.accountId ?? '',
+    filters.grouping,
+    filters.hasCategoryFilter
+      ? sortedCategoryIds(filters.includedCategoryIds).join(',')
+      : 'all',
+    filters.includeUncategorizedIncome ? '1' : '0',
+    filters.includeUncategorizedExpense ? '1' : '0',
+    sortedCategoryIds(categories.map((category) => category.id)).join(','),
+  ].join('|');
+}
+
 export function AnalysisClient({
   accounts,
   categories,
@@ -100,6 +119,114 @@ export function AnalysisClient({
   data,
   lang,
 }: AnalysisClientProps) {
+  const t = useTranslations('analysis');
+  const filterControlsKey = createAnalysisFilterDraftSyncKey(filters, categories);
+  const periods = useMemo(
+    () => [
+      ...new Set(data.incomeExpenseTrend.map((point) => point.period)),
+    ],
+    [data.incomeExpenseTrend]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-3xl font-bold">{t('title')}</h2>
+        <p className="text-muted-foreground">{t('description')}</p>
+      </div>
+
+      <AnalysisFilterControls
+        key={filterControlsKey}
+        accounts={accounts}
+        categories={categories}
+        filters={filters}
+        lang={lang}
+      />
+
+      <AnalysisSummaryCards
+        income={data.summary.income}
+        expenses={data.summary.expenses}
+        locale={lang}
+        labels={{
+          income: t('summary.income'),
+          expenses: t('summary.expenses'),
+        }}
+      />
+
+      <IncomeExpenseTrendChart
+        data={data.incomeExpenseTrend}
+        title={t('charts.incomeExpenseTrend')}
+        emptyText={t('charts.empty')}
+        locale={lang}
+        labels={{
+          income: t('summary.income'),
+          expenses: t('summary.expenses'),
+        }}
+      />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <CategoryStackedTrendChart
+          data={data.incomeStackedTrend}
+          title={t('charts.incomeStackedTrend')}
+          emptyText={t('charts.empty')}
+          locale={lang}
+        />
+        <CategoryStackedTrendChart
+          data={data.expenseStackedTrend}
+          title={t('charts.expenseStackedTrend')}
+          emptyText={t('charts.empty')}
+          locale={lang}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <CategoryBreakdownChart
+          data={data.incomeBreakdown}
+          title={t('charts.incomeBreakdown')}
+          emptyText={t('charts.empty')}
+          color="#22c55e"
+          locale={lang}
+        />
+        <CategoryBreakdownChart
+          data={data.expenseBreakdown}
+          title={t('charts.expenseBreakdown')}
+          emptyText={t('charts.empty')}
+          color="#ef4444"
+          locale={lang}
+        />
+      </div>
+
+      <CategoryTrendTable
+        rows={data.categoryTrends}
+        periods={periods}
+        title={t('charts.categoryTrendTable')}
+        emptyText={t('charts.empty')}
+        locale={lang}
+        labels={{
+          category: t('table.category'),
+          type: t('table.type'),
+          total: t('table.total'),
+          income: t('table.income'),
+          expense: t('table.expense'),
+        }}
+      />
+    </div>
+  );
+}
+
+interface AnalysisFilterControlsProps {
+  accounts: Account[];
+  categories: CategoryWithPath[];
+  filters: AnalysisFilters;
+  lang: string;
+}
+
+function AnalysisFilterControls({
+  accounts,
+  categories,
+  filters,
+  lang,
+}: AnalysisFilterControlsProps) {
   const t = useTranslations('analysis');
   const router = useRouter();
   const pathname = usePathname();
@@ -111,12 +238,6 @@ export function AnalysisClient({
   const allCategoryIds = useMemo(
     () => sortedCategoryIds(categories.map((category) => category.id)),
     [categories]
-  );
-  const periods = useMemo(
-    () => [
-      ...new Set(data.incomeExpenseTrend.map((point) => point.period)),
-    ],
-    [data.incomeExpenseTrend]
   );
 
   const pushDraft = (draft: AnalysisFilterDraft) => {
@@ -204,218 +325,143 @@ export function AnalysisClient({
   };
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-3xl font-bold">{t('title')}</h2>
-        <p className="text-muted-foreground">{t('description')}</p>
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('filters')}</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
-            <div className="space-y-2">
-              <Label htmlFor="analysis-preset">{t('dateRangePreset')}</Label>
-              <Select
-                value={filterDraft.preset}
-                onValueChange={(value) =>
-                  updateDraft((current) => ({
-                    ...current,
-                    preset: value as AnalysisDatePreset,
-                  }))
-                }
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('filters')}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
+          <div className="space-y-2">
+            <Label htmlFor="analysis-preset">{t('dateRangePreset')}</Label>
+            <Select
+              value={filterDraft.preset}
+              onValueChange={(value) =>
+                updateDraft((current) => ({
+                  ...current,
+                  preset: value as AnalysisDatePreset,
+                }))
+              }
+            >
+              <SelectTrigger
+                id="analysis-preset"
+                aria-label={t('dateRangePreset')}
               >
-                <SelectTrigger
-                  id="analysis-preset"
-                  aria-label={t('dateRangePreset')}
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {DATE_PRESET_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {t(option.labelKey)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="analysis-from">{t('from')}</Label>
-              <Input
-                id="analysis-from"
-                type="date"
-                value={filterDraft.from}
-                onChange={(event) => updateDateFilter('from', event.target.value)}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="analysis-to">{t('to')}</Label>
-              <Input
-                id="analysis-to"
-                type="date"
-                value={filterDraft.to}
-                onChange={(event) => updateDateFilter('to', event.target.value)}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="analysis-account">{t('account')}</Label>
-              <Select
-                value={filterDraft.accountId || 'all'}
-                onValueChange={(value) =>
-                  updateDraft((current) => ({
-                    ...current,
-                    accountId: value === 'all' ? '' : value,
-                  }))
-                }
-              >
-                <SelectTrigger id="analysis-account" aria-label={t('account')}>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">{t('allAccounts')}</SelectItem>
-                  {accounts.map((account) => (
-                    <SelectItem key={account.id} value={account.id.toString()}>
-                      {account.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="analysis-grouping">{t('grouping')}</Label>
-              <Select
-                value={filterDraft.grouping}
-                onValueChange={(value) =>
-                  updateDraft((current) => ({
-                    ...current,
-                    grouping: value as AnalysisGrouping,
-                  }))
-                }
-              >
-                <SelectTrigger id="analysis-grouping" aria-label={t('grouping')}>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {GROUPING_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {t(option.labelKey)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DATE_PRESET_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {t(option.labelKey)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
-          <div className="flex justify-end">
-            <Button type="button" variant="outline" onClick={resetFilters}>
-              {t('resetFilters')}
-            </Button>
+          <div className="space-y-2">
+            <Label htmlFor="analysis-from">{t('from')}</Label>
+            <Input
+              id="analysis-from"
+              type="date"
+              value={filterDraft.from}
+              onChange={(event) => updateDateFilter('from', event.target.value)}
+            />
           </div>
 
-          {filters.hasInvalidDateRange ? (
-            <div className="text-sm font-medium text-red-600" role="alert">
-              {t('invalidDateRange')}
-            </div>
-          ) : null}
+          <div className="space-y-2">
+            <Label htmlFor="analysis-to">{t('to')}</Label>
+            <Input
+              id="analysis-to"
+              type="date"
+              value={filterDraft.to}
+              onChange={(event) => updateDateFilter('to', event.target.value)}
+            />
+          </div>
 
-          <AnalysisCategoryFilter
-            categories={categories}
-            selectedCategoryIds={filterDraft.categoryIds}
-            includeUncategorizedIncome={filterDraft.includeUncategorizedIncome}
-            includeUncategorizedExpense={filterDraft.includeUncategorizedExpense}
-            labels={{
-              title: t('categories.title'),
-              income: t('categories.income'),
-              expense: t('categories.expense'),
-              uncategorizedIncome: t('categories.uncategorizedIncome'),
-              uncategorizedExpense: t('categories.uncategorizedExpense'),
-            }}
-            onChange={(next) => {
-              updateDraft((current) => ({
-                ...current,
-                categoryIds: sortedCategoryIds(next.selectedCategoryIds),
-                includeUncategorizedIncome: next.includeUncategorizedIncome,
-                includeUncategorizedExpense: next.includeUncategorizedExpense,
-              }));
-            }}
-          />
-        </CardContent>
-      </Card>
+          <div className="space-y-2">
+            <Label htmlFor="analysis-account">{t('account')}</Label>
+            <Select
+              value={filterDraft.accountId || 'all'}
+              onValueChange={(value) =>
+                updateDraft((current) => ({
+                  ...current,
+                  accountId: value === 'all' ? '' : value,
+                }))
+              }
+            >
+              <SelectTrigger id="analysis-account" aria-label={t('account')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t('allAccounts')}</SelectItem>
+                {accounts.map((account) => (
+                  <SelectItem key={account.id} value={account.id.toString()}>
+                    {account.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
 
-      <AnalysisSummaryCards
-        income={data.summary.income}
-        expenses={data.summary.expenses}
-        locale={lang}
-        labels={{
-          income: t('summary.income'),
-          expenses: t('summary.expenses'),
-        }}
-      />
+          <div className="space-y-2">
+            <Label htmlFor="analysis-grouping">{t('grouping')}</Label>
+            <Select
+              value={filterDraft.grouping}
+              onValueChange={(value) =>
+                updateDraft((current) => ({
+                  ...current,
+                  grouping: value as AnalysisGrouping,
+                }))
+              }
+            >
+              <SelectTrigger id="analysis-grouping" aria-label={t('grouping')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {GROUPING_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {t(option.labelKey)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
 
-      <IncomeExpenseTrendChart
-        data={data.incomeExpenseTrend}
-        title={t('charts.incomeExpenseTrend')}
-        emptyText={t('charts.empty')}
-        locale={lang}
-        labels={{
-          income: t('summary.income'),
-          expenses: t('summary.expenses'),
-        }}
-      />
+        <div className="flex justify-end">
+          <Button type="button" variant="outline" onClick={resetFilters}>
+            {t('resetFilters')}
+          </Button>
+        </div>
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <CategoryStackedTrendChart
-          data={data.incomeStackedTrend}
-          title={t('charts.incomeStackedTrend')}
-          emptyText={t('charts.empty')}
-          locale={lang}
+        {filters.hasInvalidDateRange ? (
+          <div className="text-sm font-medium text-red-600" role="alert">
+            {t('invalidDateRange')}
+          </div>
+        ) : null}
+
+        <AnalysisCategoryFilter
+          categories={categories}
+          selectedCategoryIds={filterDraft.categoryIds}
+          includeUncategorizedIncome={filterDraft.includeUncategorizedIncome}
+          includeUncategorizedExpense={filterDraft.includeUncategorizedExpense}
+          labels={{
+            title: t('categories.title'),
+            income: t('categories.income'),
+            expense: t('categories.expense'),
+            uncategorizedIncome: t('categories.uncategorizedIncome'),
+            uncategorizedExpense: t('categories.uncategorizedExpense'),
+          }}
+          onChange={(next) => {
+            updateDraft((current) => ({
+              ...current,
+              categoryIds: sortedCategoryIds(next.selectedCategoryIds),
+              includeUncategorizedIncome: next.includeUncategorizedIncome,
+              includeUncategorizedExpense: next.includeUncategorizedExpense,
+            }));
+          }}
         />
-        <CategoryStackedTrendChart
-          data={data.expenseStackedTrend}
-          title={t('charts.expenseStackedTrend')}
-          emptyText={t('charts.empty')}
-          locale={lang}
-        />
-      </div>
-
-      <div className="grid gap-6 lg:grid-cols-2">
-        <CategoryBreakdownChart
-          data={data.incomeBreakdown}
-          title={t('charts.incomeBreakdown')}
-          emptyText={t('charts.empty')}
-          color="#22c55e"
-          locale={lang}
-        />
-        <CategoryBreakdownChart
-          data={data.expenseBreakdown}
-          title={t('charts.expenseBreakdown')}
-          emptyText={t('charts.empty')}
-          color="#ef4444"
-          locale={lang}
-        />
-      </div>
-
-      <CategoryTrendTable
-        rows={data.categoryTrends}
-        periods={periods}
-        title={t('charts.categoryTrendTable')}
-        emptyText={t('charts.empty')}
-        locale={lang}
-        labels={{
-          category: t('table.category'),
-          type: t('table.type'),
-          total: t('table.total'),
-          income: t('table.income'),
-          expense: t('table.expense'),
-        }}
-      />
-    </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/app/(dashboard)/analysis/page.tsx
+++ b/app/(dashboard)/analysis/page.tsx
@@ -24,15 +24,25 @@ export default async function AnalysisPage({
 
   const validAccountIds = new Set(accounts.map((account) => account.id));
   const validCategoryIds = new Set(categories.map((category) => category.id));
+  const includedCategoryIds = parsedFilters.includedCategoryIds.filter((categoryId) =>
+    validCategoryIds.has(categoryId)
+  );
+  const rawCategories = resolvedSearchParams.categories;
+  const firstRawCategory = Array.isArray(rawCategories)
+    ? rawCategories[0]
+    : rawCategories;
+  const hasCategoryFilter =
+    firstRawCategory === undefined
+      ? false
+      : firstRawCategory === '' || includedCategoryIds.length > 0;
   const filters = {
     ...parsedFilters,
     accountId:
       parsedFilters.accountId && validAccountIds.has(parsedFilters.accountId)
         ? parsedFilters.accountId
         : undefined,
-    includedCategoryIds: parsedFilters.includedCategoryIds.filter((categoryId) =>
-      validCategoryIds.has(categoryId)
-    ),
+    includedCategoryIds,
+    hasCategoryFilter,
   };
 
   const data = await getTransactionAnalysis(filters);

--- a/app/(dashboard)/analysis/page.tsx
+++ b/app/(dashboard)/analysis/page.tsx
@@ -1,0 +1,49 @@
+import {
+  parseAnalysisFilters,
+  type AnalysisFilterSearchParams,
+} from '@/lib/analysis/filters';
+import { getTransactionAnalysis } from '@/lib/analytics/transaction-analysis';
+import { getAllAccounts } from '@/lib/db/accounts';
+import { getAllCategoriesWithPaths } from '@/lib/db/categories';
+import { getLangFromUrl } from '@/lib/i18n/utils';
+import { AnalysisClient } from './client';
+
+export default async function AnalysisPage({
+  searchParams,
+}: {
+  searchParams: Promise<AnalysisFilterSearchParams>;
+}) {
+  const resolvedSearchParams = await searchParams;
+  const parsedFilters = parseAnalysisFilters(resolvedSearchParams);
+
+  const [lang, accounts, categories] = await Promise.all([
+    getLangFromUrl(),
+    getAllAccounts(),
+    getAllCategoriesWithPaths(),
+  ]);
+
+  const validAccountIds = new Set(accounts.map((account) => account.id));
+  const validCategoryIds = new Set(categories.map((category) => category.id));
+  const filters = {
+    ...parsedFilters,
+    accountId:
+      parsedFilters.accountId && validAccountIds.has(parsedFilters.accountId)
+        ? parsedFilters.accountId
+        : undefined,
+    includedCategoryIds: parsedFilters.includedCategoryIds.filter((categoryId) =>
+      validCategoryIds.has(categoryId)
+    ),
+  };
+
+  const data = await getTransactionAnalysis(filters);
+
+  return (
+    <AnalysisClient
+      accounts={accounts}
+      categories={categories}
+      filters={filters}
+      data={data}
+      lang={lang}
+    />
+  );
+}

--- a/components/analysis/analysis-category-filter.tsx
+++ b/components/analysis/analysis-category-filter.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useEffect, useMemo, useRef } from 'react';
+import type { CategoryWithPath } from '@/lib/db/types';
+
+interface AnalysisCategoryFilterLabels {
+  title: string;
+  income: string;
+  expense: string;
+  uncategorizedIncome: string;
+  uncategorizedExpense: string;
+}
+
+interface AnalysisCategoryFilterValue {
+  selectedCategoryIds: number[];
+  includeUncategorizedIncome: boolean;
+  includeUncategorizedExpense: boolean;
+}
+
+interface AnalysisCategoryFilterProps extends AnalysisCategoryFilterValue {
+  categories: CategoryWithPath[];
+  labels: AnalysisCategoryFilterLabels;
+  onChange: (next: AnalysisCategoryFilterValue) => void;
+}
+
+interface CategoryCheckboxProps {
+  category: CategoryWithPath;
+  checked: boolean;
+  indeterminate: boolean;
+  onToggle: () => void;
+}
+
+function sortedIds(ids: Iterable<number>) {
+  return [...ids].sort((a, b) => a - b);
+}
+
+function CategoryCheckbox({
+  category,
+  checked,
+  indeterminate,
+  onToggle,
+}: CategoryCheckboxProps) {
+  const checkboxRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (checkboxRef.current) {
+      checkboxRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <label
+      className="flex items-center gap-2 text-sm"
+      style={{ paddingLeft: `${Math.max(category.depth - 1, 0) * 1.25}rem` }}
+    >
+      <input
+        ref={checkboxRef}
+        type="checkbox"
+        checked={checked}
+        aria-checked={indeterminate ? 'mixed' : checked}
+        onChange={onToggle}
+        className="h-4 w-4 rounded border-input"
+      />
+      <span>{category.name}</span>
+    </label>
+  );
+}
+
+export function AnalysisCategoryFilter({
+  categories,
+  selectedCategoryIds,
+  includeUncategorizedIncome,
+  includeUncategorizedExpense,
+  labels,
+  onChange,
+}: AnalysisCategoryFilterProps) {
+  const selectedSet = useMemo(
+    () => new Set(selectedCategoryIds),
+    [selectedCategoryIds]
+  );
+  const childrenByParent = useMemo(() => {
+    const children = new Map<number | null, CategoryWithPath[]>();
+
+    for (const category of categories) {
+      const siblings = children.get(category.parent_id) ?? [];
+      siblings.push(category);
+      children.set(category.parent_id, siblings);
+    }
+
+    return children;
+  }, [categories]);
+
+  const categoryIdsBySubtree = useMemo(() => {
+    const idsBySubtree = new Map<number, number[]>();
+
+    const collectIds = (category: CategoryWithPath): number[] => {
+      const childIds = (childrenByParent.get(category.id) ?? []).flatMap(
+        collectIds
+      );
+      const subtreeIds = sortedIds([category.id, ...childIds]);
+      idsBySubtree.set(category.id, subtreeIds);
+      return subtreeIds;
+    };
+
+    for (const category of categories) {
+      collectIds(category);
+    }
+
+    return idsBySubtree;
+  }, [categories, childrenByParent]);
+
+  const emitChange = (nextSelectedCategoryIds: Iterable<number>) => {
+    onChange({
+      selectedCategoryIds: sortedIds(nextSelectedCategoryIds),
+      includeUncategorizedIncome,
+      includeUncategorizedExpense,
+    });
+  };
+
+  const toggleCategory = (category: CategoryWithPath) => {
+    const subtreeIds = categoryIdsBySubtree.get(category.id) ?? [category.id];
+    const nextSelected = new Set(selectedSet);
+    const subtreeSelected = subtreeIds.every((id) => selectedSet.has(id));
+
+    for (const id of subtreeIds) {
+      if (subtreeSelected) {
+        nextSelected.delete(id);
+      } else {
+        nextSelected.add(id);
+      }
+    }
+
+    emitChange(nextSelected);
+  };
+
+  const renderGroup = (
+    categoryType: CategoryWithPath['category_type'],
+    label: string
+  ) => {
+    const groupCategories = categories
+      .filter((category) => category.category_type === categoryType)
+      .sort((a, b) => a.path.localeCompare(b.path) || a.id - b.id);
+
+    return (
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium">{label}</legend>
+        <div className="space-y-2">
+          {groupCategories.map((category) => {
+            const subtreeIds = categoryIdsBySubtree.get(category.id) ?? [
+              category.id,
+            ];
+            const selectedCount = subtreeIds.filter((id) =>
+              selectedSet.has(id)
+            ).length;
+
+            return (
+              <CategoryCheckbox
+                key={category.id}
+                category={category}
+                checked={selectedCount === subtreeIds.length}
+                indeterminate={
+                  selectedCount > 0 && selectedCount < subtreeIds.length
+                }
+                onToggle={() => toggleCategory(category)}
+              />
+            );
+          })}
+        </div>
+      </fieldset>
+    );
+  };
+
+  return (
+    <section className="space-y-4" aria-labelledby="analysis-category-filter">
+      <h3 id="analysis-category-filter" className="text-base font-semibold">
+        {labels.title}
+      </h3>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {renderGroup('income', labels.income)}
+        {renderGroup('expense', labels.expense)}
+      </div>
+
+      <div className="grid gap-3 border-t pt-4 md:grid-cols-2">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={includeUncategorizedIncome}
+            onChange={() =>
+              onChange({
+                selectedCategoryIds: sortedIds(selectedCategoryIds),
+                includeUncategorizedIncome: !includeUncategorizedIncome,
+                includeUncategorizedExpense,
+              })
+            }
+            className="h-4 w-4 rounded border-input"
+          />
+          <span>{labels.uncategorizedIncome}</span>
+        </label>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={includeUncategorizedExpense}
+            onChange={() =>
+              onChange({
+                selectedCategoryIds: sortedIds(selectedCategoryIds),
+                includeUncategorizedIncome,
+                includeUncategorizedExpense: !includeUncategorizedExpense,
+              })
+            }
+            className="h-4 w-4 rounded border-input"
+          />
+          <span>{labels.uncategorizedExpense}</span>
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/components/analysis/analysis-summary-cards.tsx
+++ b/components/analysis/analysis-summary-cards.tsx
@@ -1,0 +1,55 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface AnalysisSummaryCardsProps {
+  income: string;
+  expenses: string;
+  locale: string;
+  labels: {
+    income: string;
+    expenses: string;
+  };
+}
+
+function formatCurrency(amount: string, locale: string) {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: locale === 'pt-BR' ? 'BRL' : 'USD',
+  }).format(parseFloat(amount));
+}
+
+export function AnalysisSummaryCards({
+  income,
+  expenses,
+  locale,
+  labels,
+}: AnalysisSummaryCardsProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {labels.income}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold text-green-600">
+            {formatCurrency(income, locale)}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {labels.expenses}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold text-red-600">
+            {formatCurrency(expenses, locale)}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/analysis/category-breakdown-chart.tsx
+++ b/components/analysis/category-breakdown-chart.tsx
@@ -17,6 +17,16 @@ interface CategoryBreakdownChartProps {
   title: string;
   emptyText: string;
   color: string;
+  locale: string;
+}
+
+function formatCurrency(amount: unknown, locale: string) {
+  const parsedAmount = typeof amount === 'number' ? amount : parseFloat(String(amount));
+
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: locale === 'pt-BR' ? 'BRL' : 'USD',
+  }).format(Number.isNaN(parsedAmount) ? 0 : parsedAmount);
 }
 
 export function CategoryBreakdownChart({
@@ -24,6 +34,7 @@ export function CategoryBreakdownChart({
   title,
   emptyText,
   color,
+  locale,
 }: CategoryBreakdownChartProps) {
   const chartData = data.map((item) => ({
     category: item.category_path || item.category_name,
@@ -44,13 +55,13 @@ export function CategoryBreakdownChart({
           <ResponsiveContainer width="100%" height={320}>
             <BarChart data={chartData} layout="vertical">
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis type="number" />
+              <XAxis type="number" tickFormatter={(value) => formatCurrency(value, locale)} />
               <YAxis
                 dataKey="category"
                 type="category"
                 width={160}
               />
-              <Tooltip />
+              <Tooltip formatter={(value) => formatCurrency(value, locale)} />
               <Bar dataKey="amount" fill={color} />
             </BarChart>
           </ResponsiveContainer>

--- a/components/analysis/category-breakdown-chart.tsx
+++ b/components/analysis/category-breakdown-chart.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { AnalysisCategoryBreakdown } from '@/lib/analytics/transaction-analysis';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface CategoryBreakdownChartProps {
+  data: AnalysisCategoryBreakdown[];
+  title: string;
+  emptyText: string;
+  color: string;
+}
+
+export function CategoryBreakdownChart({
+  data,
+  title,
+  emptyText,
+  color,
+}: CategoryBreakdownChartProps) {
+  const chartData = data.map((item) => ({
+    category: item.category_path || item.category_name,
+    amount: parseFloat(item.amount),
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {chartData.length === 0 ? (
+          <div className="flex h-80 items-center justify-center text-sm text-muted-foreground">
+            {emptyText}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart data={chartData} layout="vertical">
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis type="number" />
+              <YAxis
+                dataKey="category"
+                type="category"
+                width={160}
+              />
+              <Tooltip />
+              <Bar dataKey="amount" fill={color} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analysis/category-stacked-trend-chart.tsx
+++ b/components/analysis/category-stacked-trend-chart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import type { StackedTrendPoint } from '@/lib/analytics/transaction-analysis';
+import type { StackedTrendData } from '@/lib/analytics/transaction-analysis';
 import {
   Bar,
   BarChart,
@@ -28,7 +28,7 @@ const STACK_COLORS = [
 ];
 
 interface CategoryStackedTrendChartProps {
-  data: StackedTrendPoint[];
+  data: StackedTrendData;
   title: string;
   emptyText: string;
   locale: string;
@@ -49,16 +49,13 @@ export function CategoryStackedTrendChart({
   emptyText,
   locale,
 }: CategoryStackedTrendChartProps) {
-  const stackKeys = Array.from(
-    new Set(data.flatMap((point) => Object.keys(point).filter((key) => key !== 'period')))
-  );
-  const chartData = data.map((point) => {
+  const chartData = data.points.map((point) => {
     const parsedPoint: Record<string, string | number> = {
       period: point.period,
     };
 
-    for (const key of stackKeys) {
-      parsedPoint[key] = parseFloat(point[key] ?? '0');
+    for (const series of data.series) {
+      parsedPoint[series.key] = parseFloat(point.values[series.key] ?? '0');
     }
 
     return parsedPoint;
@@ -70,7 +67,7 @@ export function CategoryStackedTrendChart({
         <CardTitle>{title}</CardTitle>
       </CardHeader>
       <CardContent>
-        {chartData.length === 0 || stackKeys.length === 0 ? (
+        {chartData.length === 0 || data.series.length === 0 ? (
           <div className="flex h-80 items-center justify-center text-sm text-muted-foreground">
             {emptyText}
           </div>
@@ -82,10 +79,11 @@ export function CategoryStackedTrendChart({
               <YAxis tickFormatter={(value) => formatCurrency(value, locale)} />
               <Tooltip formatter={(value) => formatCurrency(value, locale)} />
               <Legend />
-              {stackKeys.map((key, index) => (
+              {data.series.map((series, index) => (
                 <Bar
-                  key={key}
-                  dataKey={key}
+                  key={series.key}
+                  dataKey={series.key}
+                  name={series.name}
                   stackId="category"
                   fill={STACK_COLORS[index % STACK_COLORS.length]}
                 />

--- a/components/analysis/category-stacked-trend-chart.tsx
+++ b/components/analysis/category-stacked-trend-chart.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { StackedTrendPoint } from '@/lib/analytics/transaction-analysis';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+const STACK_COLORS = [
+  '#2563eb',
+  '#16a34a',
+  '#dc2626',
+  '#9333ea',
+  '#ea580c',
+  '#0891b2',
+  '#65a30d',
+  '#c026d3',
+  '#ca8a04',
+  '#4f46e5',
+  '#64748b',
+];
+
+interface CategoryStackedTrendChartProps {
+  data: StackedTrendPoint[];
+  title: string;
+  emptyText: string;
+}
+
+export function CategoryStackedTrendChart({
+  data,
+  title,
+  emptyText,
+}: CategoryStackedTrendChartProps) {
+  const stackKeys = Array.from(
+    new Set(data.flatMap((point) => Object.keys(point).filter((key) => key !== 'period')))
+  );
+  const chartData = data.map((point) => {
+    const parsedPoint: Record<string, string | number> = {
+      period: point.period,
+    };
+
+    for (const key of stackKeys) {
+      parsedPoint[key] = parseFloat(point[key] ?? '0');
+    }
+
+    return parsedPoint;
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {chartData.length === 0 || stackKeys.length === 0 ? (
+          <div className="flex h-80 items-center justify-center text-sm text-muted-foreground">
+            {emptyText}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="period" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              {stackKeys.map((key, index) => (
+                <Bar
+                  key={key}
+                  dataKey={key}
+                  stackId="category"
+                  fill={STACK_COLORS[index % STACK_COLORS.length]}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analysis/category-stacked-trend-chart.tsx
+++ b/components/analysis/category-stacked-trend-chart.tsx
@@ -31,12 +31,23 @@ interface CategoryStackedTrendChartProps {
   data: StackedTrendPoint[];
   title: string;
   emptyText: string;
+  locale: string;
+}
+
+function formatCurrency(amount: unknown, locale: string) {
+  const parsedAmount = typeof amount === 'number' ? amount : parseFloat(String(amount));
+
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: locale === 'pt-BR' ? 'BRL' : 'USD',
+  }).format(Number.isNaN(parsedAmount) ? 0 : parsedAmount);
 }
 
 export function CategoryStackedTrendChart({
   data,
   title,
   emptyText,
+  locale,
 }: CategoryStackedTrendChartProps) {
   const stackKeys = Array.from(
     new Set(data.flatMap((point) => Object.keys(point).filter((key) => key !== 'period')))
@@ -68,8 +79,8 @@ export function CategoryStackedTrendChart({
             <BarChart data={chartData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="period" />
-              <YAxis />
-              <Tooltip />
+              <YAxis tickFormatter={(value) => formatCurrency(value, locale)} />
+              <Tooltip formatter={(value) => formatCurrency(value, locale)} />
               <Legend />
               {stackKeys.map((key, index) => (
                 <Bar

--- a/components/analysis/category-trend-table.tsx
+++ b/components/analysis/category-trend-table.tsx
@@ -1,0 +1,96 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { CategoryTrendRow } from '@/lib/analytics/transaction-analysis';
+
+interface CategoryTrendTableProps {
+  rows: CategoryTrendRow[];
+  periods: string[];
+  title: string;
+  emptyText: string;
+  locale: string;
+  labels: {
+    category: string;
+    type: string;
+    total: string;
+    income: string;
+    expense: string;
+  };
+}
+
+function formatCurrency(amount: string, locale: string) {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: locale === 'pt-BR' ? 'BRL' : 'USD',
+  }).format(parseFloat(amount));
+}
+
+export function CategoryTrendTable({
+  rows,
+  periods,
+  title,
+  emptyText,
+  locale,
+  labels,
+}: CategoryTrendTableProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{labels.category}</TableHead>
+              <TableHead>{labels.type}</TableHead>
+              <TableHead className="text-right">{labels.total}</TableHead>
+              {periods.map((period) => (
+                <TableHead key={period} className="text-right">
+                  {period}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={3 + periods.length}
+                  className="text-center text-muted-foreground"
+                >
+                  {emptyText}
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => (
+                <TableRow key={row.categoryKey}>
+                  <TableCell className="font-medium">
+                    {row.categoryPath}
+                  </TableCell>
+                  <TableCell>
+                    {row.categoryType === 'income' ? labels.income : labels.expense}
+                  </TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(row.total, locale)}
+                  </TableCell>
+                  {periods.map((period) => (
+                    <TableCell key={period} className="text-right">
+                      {formatCurrency(row.periods[period] ?? '0', locale)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analysis/income-expense-trend-chart.tsx
+++ b/components/analysis/income-expense-trend-chart.tsx
@@ -17,17 +17,33 @@ interface IncomeExpenseTrendChartProps {
   data: IncomeExpenseTrendPoint[];
   title: string;
   emptyText: string;
+  locale: string;
+  labels: {
+    income: string;
+    expenses: string;
+  };
+}
+
+function formatCurrency(amount: unknown, locale: string) {
+  const parsedAmount = typeof amount === 'number' ? amount : parseFloat(String(amount));
+
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: locale === 'pt-BR' ? 'BRL' : 'USD',
+  }).format(Number.isNaN(parsedAmount) ? 0 : parsedAmount);
 }
 
 export function IncomeExpenseTrendChart({
   data,
   title,
   emptyText,
+  locale,
+  labels,
 }: IncomeExpenseTrendChartProps) {
   const chartData = data.map((item) => ({
     period: item.period,
-    Income: parseFloat(item.income),
-    Expenses: parseFloat(item.expenses),
+    income: parseFloat(item.income),
+    expenses: parseFloat(item.expenses),
   }));
 
   return (
@@ -45,11 +61,11 @@ export function IncomeExpenseTrendChart({
             <BarChart data={chartData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="period" />
-              <YAxis />
-              <Tooltip />
+              <YAxis tickFormatter={(value) => formatCurrency(value, locale)} />
+              <Tooltip formatter={(value) => formatCurrency(value, locale)} />
               <Legend />
-              <Bar dataKey="Income" fill="#22c55e" />
-              <Bar dataKey="Expenses" fill="#ef4444" />
+              <Bar dataKey="income" name={labels.income} fill="#22c55e" />
+              <Bar dataKey="expenses" name={labels.expenses} fill="#ef4444" />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/components/analysis/income-expense-trend-chart.tsx
+++ b/components/analysis/income-expense-trend-chart.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { IncomeExpenseTrendPoint } from '@/lib/analytics/transaction-analysis';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface IncomeExpenseTrendChartProps {
+  data: IncomeExpenseTrendPoint[];
+  title: string;
+  emptyText: string;
+}
+
+export function IncomeExpenseTrendChart({
+  data,
+  title,
+  emptyText,
+}: IncomeExpenseTrendChartProps) {
+  const chartData = data.map((item) => ({
+    period: item.period,
+    Income: parseFloat(item.income),
+    Expenses: parseFloat(item.expenses),
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {chartData.length === 0 ? (
+          <div className="flex h-80 items-center justify-center text-sm text-muted-foreground">
+            {emptyText}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="period" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="Income" fill="#22c55e" />
+              <Bar dataKey="Expenses" fill="#ef4444" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/dashboard/nav.tsx
+++ b/components/dashboard/nav.tsx
@@ -28,6 +28,7 @@ export function DashboardNav() {
     { href: `/?lang=${lang}`, label: t('dashboard') },
     { href: `/accounts?lang=${lang}`, label: t('accounts') },
     { href: `/transactions?lang=${lang}`, label: t('transactions') },
+    { href: `/analysis?lang=${lang}`, label: t('analysis') },
   ];
 
   const rentalsLinks = [

--- a/docs/superpowers/plans/2026-05-10-transaction-analysis.md
+++ b/docs/superpowers/plans/2026-05-10-transaction-analysis.md
@@ -1,0 +1,2163 @@
+# Transaction Analysis View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a dedicated `/analysis` page that analyzes selected-range income and expense trends with date, account, grouping, and hierarchy-aware category filters.
+
+**Architecture:** Add URL-driven filter parsing in `lib/analysis/filters.ts`, page-specific analytics in `lib/analytics/transaction-analysis.ts`, and a protected App Router page at `app/(dashboard)/analysis`. The server page validates IDs and fetches data; focused client components render filters, Recharts visualizations, and the trend table.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Tailwind CSS, Recharts, PostgreSQL via `@vercel/postgres`, next-intl, Vitest, Testing Library, Playwright.
+
+---
+
+## Approved Spec
+
+Implement the approved design in `docs/superpowers/specs/2026-05-10-transaction-analysis-design.md`.
+
+## File Structure
+
+Create:
+
+- `lib/analysis/filters.ts` - Parse and resolve analysis URL filters.
+- `__tests__/lib/analysis/filters.test.ts` - Unit tests for presets, custom dates, grouping, IDs, and invalid ranges.
+- `lib/analytics/transaction-analysis.ts` - Query and shape transaction analysis data.
+- `__tests__/lib/analytics/transaction-analysis.test.ts` - Unit tests for analytics SQL calls and shaping helpers.
+- `components/analysis/analysis-summary-cards.tsx` - Income and expense total cards.
+- `components/analysis/income-expense-trend-chart.tsx` - Grouped bar chart for income vs expenses.
+- `components/analysis/category-breakdown-chart.tsx` - Horizontal bar chart for selected-range category totals.
+- `components/analysis/category-stacked-trend-chart.tsx` - Stacked bar chart for top 10 categories plus Other.
+- `components/analysis/category-trend-table.tsx` - Exact category totals by period.
+- `components/analysis/analysis-category-filter.tsx` - Hierarchy-aware category checkbox tree.
+- `app/(dashboard)/analysis/page.tsx` - Server component for route composition.
+- `app/(dashboard)/analysis/client.tsx` - Client component for filters, URL updates, and layout.
+- `__tests__/components/analysis/analysis-category-filter.test.tsx` - Category tree behavior tests.
+- `__tests__/app/analysis-client.test.tsx` - URL update and rendering tests.
+- `e2e/11-analysis.spec.ts` - E2E coverage for the new route and filters.
+
+Modify:
+
+- `components/dashboard/nav.tsx` - Add Analysis navigation link.
+- `messages/en.json` - Add `nav.analysis` and `analysis.*` strings.
+- `messages/pt-BR.json` - Add Portuguese equivalents.
+
+Do not modify the existing dashboard charts except for shared utility extraction if a test makes that necessary.
+
+## Task 1: Analysis Filter Parser
+
+**Files:**
+
+- Create: `lib/analysis/filters.ts`
+- Create: `__tests__/lib/analysis/filters.test.ts`
+
+- [ ] **Step 1: Write failing filter parser tests**
+
+Create `__tests__/lib/analysis/filters.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseAnalysisFilters,
+  resolveAnalysisDateRange,
+  resolveAnalysisGrouping,
+} from '@/lib/analysis/filters';
+
+describe('analysis filters', () => {
+  it('defaults to last 3 months, all accounts, all categories, and adaptive grouping', () => {
+    vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+    const parsed = parseAnalysisFilters({});
+
+    expect(parsed.preset).toBe('last-3-months');
+    expect(parsed.accountId).toBeUndefined();
+    expect(parsed.grouping).toBe('adaptive');
+    expect(parsed.includedCategoryIds).toEqual([]);
+    expect(parsed.includeUncategorizedIncome).toBe(true);
+    expect(parsed.includeUncategorizedExpense).toBe(true);
+    expect(parsed.hasCategoryFilter).toBe(false);
+    expect(parsed.hasInvalidDateRange).toBe(false);
+    expect(parsed.from).toBe('2026-02-10');
+    expect(parsed.to).toBe('2026-05-10');
+  });
+
+  it('resolves fixed presets from the current date', () => {
+    vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+    expect(resolveAnalysisDateRange({ preset: 'this-month' })).toEqual({
+      from: '2026-05-01',
+      to: '2026-05-10',
+      preset: 'this-month',
+    });
+    expect(resolveAnalysisDateRange({ preset: 'last-month' })).toEqual({
+      from: '2026-04-01',
+      to: '2026-04-30',
+      preset: 'last-month',
+    });
+    expect(resolveAnalysisDateRange({ preset: 'last-year' })).toEqual({
+      from: '2025-01-01',
+      to: '2025-12-31',
+      preset: 'last-year',
+    });
+  });
+
+  it('uses custom dates when both custom dates are valid', () => {
+    const parsed = parseAnalysisFilters({
+      preset: 'custom',
+      from: '2026-01-15',
+      to: '2026-03-20',
+    });
+
+    expect(parsed.preset).toBe('custom');
+    expect(parsed.from).toBe('2026-01-15');
+    expect(parsed.to).toBe('2026-03-20');
+    expect(parsed.hasInvalidDateRange).toBe(false);
+  });
+
+  it('marks reversed custom ranges invalid', () => {
+    const parsed = parseAnalysisFilters({
+      preset: 'custom',
+      from: '2026-03-20',
+      to: '2026-01-15',
+    });
+
+    expect(parsed.hasInvalidDateRange).toBe(true);
+    expect(parsed.from).toBe('2026-03-20');
+    expect(parsed.to).toBe('2026-01-15');
+  });
+
+  it('falls back to last 3 months when custom dates are missing', () => {
+    vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+
+    const parsed = parseAnalysisFilters({ preset: 'custom', from: '2026-01-01' });
+
+    expect(parsed.preset).toBe('last-3-months');
+    expect(parsed.from).toBe('2026-02-10');
+    expect(parsed.to).toBe('2026-05-10');
+  });
+
+  it('parses valid account, category IDs, grouping, and uncategorized flags', () => {
+    const parsed = parseAnalysisFilters({
+      accountId: '2',
+      grouping: 'weekly',
+      categories: '4,7,9',
+      uncategorizedIncome: '0',
+      uncategorizedExpense: '1',
+    });
+
+    expect(parsed.accountId).toBe(2);
+    expect(parsed.grouping).toBe('weekly');
+    expect(parsed.includedCategoryIds).toEqual([4, 7, 9]);
+    expect(parsed.hasCategoryFilter).toBe(true);
+    expect(parsed.includeUncategorizedIncome).toBe(false);
+    expect(parsed.includeUncategorizedExpense).toBe(true);
+  });
+
+  it('ignores malformed IDs and unknown grouping values', () => {
+    const parsed = parseAnalysisFilters({
+      accountId: '-1',
+      grouping: 'quarterly',
+      categories: 'abc,3,9007199254740993,3',
+    });
+
+    expect(parsed.accountId).toBeUndefined();
+    expect(parsed.grouping).toBe('adaptive');
+    expect(parsed.includedCategoryIds).toEqual([3]);
+  });
+
+  it('resolves adaptive grouping by range length', () => {
+    expect(resolveAnalysisGrouping('adaptive', '2026-05-01', '2026-05-31')).toBe('daily');
+    expect(resolveAnalysisGrouping('adaptive', '2026-01-01', '2026-05-31')).toBe('weekly');
+    expect(resolveAnalysisGrouping('adaptive', '2025-01-01', '2026-05-31')).toBe('monthly');
+    expect(resolveAnalysisGrouping('monthly', '2026-05-01', '2026-05-31')).toBe('monthly');
+  });
+});
+```
+
+- [ ] **Step 2: Run parser tests and verify they fail**
+
+Run:
+
+```bash
+npm test -- --run __tests__/lib/analysis/filters.test.ts
+```
+
+Expected: FAIL because `lib/analysis/filters.ts` does not exist.
+
+- [ ] **Step 3: Implement the parser**
+
+Create `lib/analysis/filters.ts`:
+
+```ts
+export type AnalysisDatePreset =
+  | 'this-month'
+  | 'last-month'
+  | 'last-3-months'
+  | 'last-90-days'
+  | 'this-year'
+  | 'ytd'
+  | 'last-year'
+  | 'custom';
+
+export type AnalysisGrouping = 'adaptive' | 'daily' | 'weekly' | 'monthly';
+export type ResolvedAnalysisGrouping = Exclude<AnalysisGrouping, 'adaptive'>;
+
+export interface AnalysisFilters {
+  preset: AnalysisDatePreset;
+  from: string;
+  to: string;
+  accountId?: number;
+  grouping: AnalysisGrouping;
+  resolvedGrouping: ResolvedAnalysisGrouping;
+  includedCategoryIds: number[];
+  hasCategoryFilter: boolean;
+  includeUncategorizedIncome: boolean;
+  includeUncategorizedExpense: boolean;
+  hasInvalidDateRange: boolean;
+}
+
+type QueryValue = string | string[] | undefined;
+export type AnalysisFilterSearchParams = Record<string, QueryValue>;
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const POSITIVE_INTEGER_RE = /^\d+$/;
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
+const PRESETS = new Set<AnalysisDatePreset>([
+  'this-month',
+  'last-month',
+  'last-3-months',
+  'last-90-days',
+  'this-year',
+  'ytd',
+  'last-year',
+  'custom',
+]);
+const GROUPINGS = new Set<AnalysisGrouping>(['adaptive', 'daily', 'weekly', 'monthly']);
+
+function firstValue(value: QueryValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function addUtcMonths(date: Date, months: number): Date {
+  const next = new Date(date);
+  next.setUTCMonth(next.getUTCMonth() + months);
+  return next;
+}
+
+function startOfUtcMonth(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+function startOfUtcYear(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+}
+
+function parseIsoDate(value: QueryValue): string | undefined {
+  const raw = firstValue(value);
+  if (!raw || !ISO_DATE_RE.test(raw)) return undefined;
+  const parsed = new Date(`${raw}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime()) || toIsoDate(parsed) !== raw ? undefined : raw;
+}
+
+function parsePositiveInteger(value: QueryValue): number | undefined {
+  const raw = firstValue(value);
+  if (!raw || !POSITIVE_INTEGER_RE.test(raw)) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return parsed > 0 && parsed <= POSTGRES_INTEGER_MAX ? parsed : undefined;
+}
+
+function parseBooleanFlag(value: QueryValue, defaultValue: boolean): boolean {
+  const raw = firstValue(value);
+  if (raw === '0' || raw === 'false') return false;
+  if (raw === '1' || raw === 'true') return true;
+  return defaultValue;
+}
+
+function parsePreset(value: QueryValue): AnalysisDatePreset {
+  const raw = firstValue(value);
+  return raw && PRESETS.has(raw as AnalysisDatePreset)
+    ? (raw as AnalysisDatePreset)
+    : 'last-3-months';
+}
+
+function parseGrouping(value: QueryValue): AnalysisGrouping {
+  const raw = firstValue(value);
+  return raw && GROUPINGS.has(raw as AnalysisGrouping)
+    ? (raw as AnalysisGrouping)
+    : 'adaptive';
+}
+
+function parseCategoryIds(value: QueryValue): number[] {
+  const raw = firstValue(value);
+  if (!raw) return [];
+  return Array.from(
+    new Set(
+      raw
+        .split(',')
+        .map((part) => parsePositiveInteger(part.trim()))
+        .filter((id): id is number => id !== undefined)
+    )
+  ).sort((a, b) => a - b);
+}
+
+export function resolveAnalysisDateRange(input: {
+  preset?: AnalysisDatePreset;
+  from?: string;
+  to?: string;
+}): { preset: AnalysisDatePreset; from: string; to: string } {
+  const today = new Date();
+  const todayUtc = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+  const preset = input.preset ?? 'last-3-months';
+
+  if (preset === 'custom' && input.from && input.to) {
+    return { preset, from: input.from, to: input.to };
+  }
+
+  if (preset === 'this-month') {
+    return { preset, from: toIsoDate(startOfUtcMonth(todayUtc)), to: toIsoDate(todayUtc) };
+  }
+  if (preset === 'last-month') {
+    const firstThisMonth = startOfUtcMonth(todayUtc);
+    const firstLastMonth = addUtcMonths(firstThisMonth, -1);
+    return { preset, from: toIsoDate(firstLastMonth), to: toIsoDate(addUtcDays(firstThisMonth, -1)) };
+  }
+  if (preset === 'last-90-days') {
+    return { preset, from: toIsoDate(addUtcDays(todayUtc, -90)), to: toIsoDate(todayUtc) };
+  }
+  if (preset === 'this-year' || preset === 'ytd') {
+    return { preset, from: toIsoDate(startOfUtcYear(todayUtc)), to: toIsoDate(todayUtc) };
+  }
+  if (preset === 'last-year') {
+    const year = todayUtc.getUTCFullYear() - 1;
+    return { preset, from: `${year}-01-01`, to: `${year}-12-31` };
+  }
+
+  return {
+    preset: 'last-3-months',
+    from: toIsoDate(addUtcMonths(todayUtc, -3)),
+    to: toIsoDate(todayUtc),
+  };
+}
+
+function inclusiveDayCount(from: string, to: string): number {
+  const fromMs = new Date(`${from}T00:00:00Z`).getTime();
+  const toMs = new Date(`${to}T00:00:00Z`).getTime();
+  return Math.floor((toMs - fromMs) / 86_400_000) + 1;
+}
+
+export function resolveAnalysisGrouping(
+  grouping: AnalysisGrouping,
+  from: string,
+  to: string
+): ResolvedAnalysisGrouping {
+  if (grouping !== 'adaptive') return grouping;
+  const days = inclusiveDayCount(from, to);
+  if (days <= 45) return 'daily';
+  if (days <= 180) return 'weekly';
+  return 'monthly';
+}
+
+export function parseAnalysisFilters(searchParams: AnalysisFilterSearchParams): AnalysisFilters {
+  const requestedPreset = parsePreset(searchParams.preset);
+  const customFrom = parseIsoDate(searchParams.from);
+  const customTo = parseIsoDate(searchParams.to);
+  const range = resolveAnalysisDateRange({
+    preset: requestedPreset,
+    from: customFrom,
+    to: customTo,
+  });
+  const grouping = parseGrouping(searchParams.grouping);
+  const includedCategoryIds = parseCategoryIds(searchParams.categories);
+  const hasInvalidDateRange = range.from > range.to;
+
+  return {
+    preset: range.preset,
+    from: range.from,
+    to: range.to,
+    accountId: parsePositiveInteger(searchParams.accountId),
+    grouping,
+    resolvedGrouping: resolveAnalysisGrouping(grouping, range.from, range.to),
+    includedCategoryIds,
+    hasCategoryFilter: firstValue(searchParams.categories) !== undefined,
+    includeUncategorizedIncome: parseBooleanFlag(searchParams.uncategorizedIncome, true),
+    includeUncategorizedExpense: parseBooleanFlag(searchParams.uncategorizedExpense, true),
+    hasInvalidDateRange,
+  };
+}
+```
+
+- [ ] **Step 4: Run parser tests and verify they pass**
+
+Run:
+
+```bash
+npm test -- --run __tests__/lib/analysis/filters.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit parser work**
+
+```bash
+git add lib/analysis/filters.ts __tests__/lib/analysis/filters.test.ts
+git commit -m "feat: add analysis filter parser"
+```
+
+## Task 2: Transaction Analysis Analytics
+
+**Files:**
+
+- Create: `lib/analytics/transaction-analysis.ts`
+- Create: `__tests__/lib/analytics/transaction-analysis.test.ts`
+
+- [ ] **Step 1: Write failing analytics tests**
+
+Create `__tests__/lib/analytics/transaction-analysis.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildAnalysisWhereClause,
+  getTransactionAnalysis,
+  groupStackedTrendRows,
+} from '@/lib/analytics/transaction-analysis';
+import { AnalysisFilters } from '@/lib/analysis/filters';
+
+vi.mock('@/lib/db', () => ({
+  queryMany: vi.fn(),
+  queryOne: vi.fn(),
+}));
+
+const filters: AnalysisFilters = {
+  preset: 'last-3-months',
+  from: '2026-02-10',
+  to: '2026-05-10',
+  accountId: 2,
+  grouping: 'adaptive',
+  resolvedGrouping: 'weekly',
+  includedCategoryIds: [4, 7],
+  hasCategoryFilter: true,
+  includeUncategorizedIncome: true,
+  includeUncategorizedExpense: false,
+  hasInvalidDateRange: false,
+};
+
+describe('transaction analysis analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds a parameterized where clause for date, account, categories, and uncategorized flags', () => {
+    const where = buildAnalysisWhereClause(filters);
+
+    expect(where.whereSql).toContain('t.date >= $1');
+    expect(where.whereSql).toContain('t.date <= $2');
+    expect(where.whereSql).toContain('t.account_id = $3');
+    expect(where.whereSql).toContain('t.category_id = ANY($4::int[])');
+    expect(where.whereSql).toContain('t.category_id IS NULL AND t.amount > 0');
+    expect(where.whereSql).not.toContain('t.category_id IS NULL AND t.amount < 0');
+    expect(where.params).toEqual(['2026-02-10', '2026-05-10', 2, [4, 7]]);
+  });
+
+  it('returns empty analysis without querying when range is invalid', async () => {
+    const { queryMany, queryOne } = await import('@/lib/db');
+
+    const result = await getTransactionAnalysis({
+      ...filters,
+      hasInvalidDateRange: true,
+    });
+
+    expect(result.summary).toEqual({ income: '0.00', expenses: '0.00' });
+    expect(result.incomeExpenseTrend).toEqual([]);
+    expect(queryOne).not.toHaveBeenCalled();
+    expect(queryMany).not.toHaveBeenCalled();
+  });
+
+  it('fetches summary, trend, breakdowns, stacked trends, and table data', async () => {
+    const { queryMany, queryOne } = await import('@/lib/db');
+    vi.mocked(queryOne).mockResolvedValue({ income: '1000.00', expenses: '450.00' });
+    vi.mocked(queryMany)
+      .mockResolvedValueOnce([{ period: '2026-05-04', income: '1000.00', expenses: '450.00' }])
+      .mockResolvedValueOnce([{ category_id: 7, category_name: 'Rent', category_path: 'Housing > Rent', amount: '400.00' }])
+      .mockResolvedValueOnce([{ category_id: 4, category_name: 'Salary', category_path: 'Salary', amount: '1000.00' }])
+      .mockResolvedValueOnce([{ period: '2026-05-04', category_key: '7', category_path: 'Housing > Rent', amount: '400.00' }])
+      .mockResolvedValueOnce([{ period: '2026-05-04', category_key: '4', category_path: 'Salary', amount: '1000.00' }])
+      .mockResolvedValueOnce([{ category_key: '7', category_type: 'expense', category_path: 'Housing > Rent', period: '2026-05-04', amount: '400.00' }]);
+
+    const result = await getTransactionAnalysis(filters);
+
+    expect(result.summary).toEqual({ income: '1000.00', expenses: '450.00' });
+    expect(result.expenseBreakdown[0].percentage).toBe(100);
+    expect(result.incomeBreakdown[0].percentage).toBe(100);
+    expect(result.expenseStackedTrend[0]).toMatchObject({
+      period: '2026-05-04',
+      'Housing > Rent': 400,
+    });
+    expect(result.categoryTrendRows[0].total).toBe(400);
+    expect(queryOne).toHaveBeenCalledTimes(1);
+    expect(queryMany).toHaveBeenCalledTimes(6);
+  });
+
+  it('groups stacked rows into top 10 categories plus Other', () => {
+    const rows = Array.from({ length: 12 }, (_, index) => ({
+      period: '2026-05',
+      category_key: String(index + 1),
+      category_path: `Category ${index + 1}`,
+      amount: String(120 - index),
+    }));
+
+    const result = groupStackedTrendRows(rows);
+
+    expect(Object.keys(result[0]).filter((key) => key !== 'period')).toHaveLength(11);
+    expect(result[0].Other).toBe(109 + 108);
+    expect(result[0]['Category 1']).toBe(120);
+  });
+});
+```
+
+- [ ] **Step 2: Run analytics tests and verify they fail**
+
+Run:
+
+```bash
+npm test -- --run __tests__/lib/analytics/transaction-analysis.test.ts
+```
+
+Expected: FAIL because `lib/analytics/transaction-analysis.ts` does not exist.
+
+- [ ] **Step 3: Implement analytics types and helpers**
+
+Create `lib/analytics/transaction-analysis.ts` with these exports and helper signatures:
+
+```ts
+import { queryMany, queryOne } from '@/lib/db';
+import { AnalysisFilters, ResolvedAnalysisGrouping } from '@/lib/analysis/filters';
+
+export interface AnalysisSummary {
+  income: string;
+  expenses: string;
+}
+
+export interface IncomeExpenseTrendPoint {
+  period: string;
+  income: string;
+  expenses: string;
+}
+
+export interface AnalysisCategoryBreakdown {
+  category_id: number | null;
+  category_name: string;
+  category_path: string;
+  amount: string;
+  percentage: number;
+}
+
+interface RawStackedTrendRow {
+  period: string;
+  category_key: string;
+  category_path: string;
+  amount: string;
+}
+
+export interface StackedTrendPoint {
+  period: string;
+  [categoryPath: string]: string | number;
+}
+
+interface RawCategoryTrendRow {
+  category_key: string;
+  category_type: 'income' | 'expense';
+  category_path: string;
+  period: string;
+  amount: string;
+}
+
+export interface CategoryTrendRow {
+  categoryKey: string;
+  categoryType: 'income' | 'expense';
+  categoryPath: string;
+  total: number;
+  periods: Record<string, number>;
+}
+
+export interface TransactionAnalysisData {
+  summary: AnalysisSummary;
+  incomeExpenseTrend: IncomeExpenseTrendPoint[];
+  expenseBreakdown: AnalysisCategoryBreakdown[];
+  incomeBreakdown: AnalysisCategoryBreakdown[];
+  expenseStackedTrend: StackedTrendPoint[];
+  incomeStackedTrend: StackedTrendPoint[];
+  categoryTrendRows: CategoryTrendRow[];
+}
+
+export function emptyTransactionAnalysis(): TransactionAnalysisData {
+  return {
+    summary: { income: '0.00', expenses: '0.00' },
+    incomeExpenseTrend: [],
+    expenseBreakdown: [],
+    incomeBreakdown: [],
+    expenseStackedTrend: [],
+    incomeStackedTrend: [],
+    categoryTrendRows: [],
+  };
+}
+
+export function periodExpression(grouping: ResolvedAnalysisGrouping): string {
+  if (grouping === 'daily') return "TO_CHAR(t.date, 'YYYY-MM-DD')";
+  if (grouping === 'weekly') return "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')";
+  return "TO_CHAR(DATE_TRUNC('month', t.date), 'YYYY-MM')";
+}
+
+export function buildAnalysisWhereClause(filters: AnalysisFilters): {
+  whereSql: string;
+  params: Array<string | number | number[]>;
+} {
+  const clauses = ['t.date >= $1', 't.date <= $2'];
+  const params: Array<string | number | number[]> = [filters.from, filters.to];
+
+  if (filters.accountId) {
+    params.push(filters.accountId);
+    clauses.push(`t.account_id = $${params.length}`);
+  }
+
+  if (filters.hasCategoryFilter) {
+    const categoryClauses: string[] = [];
+    if (filters.includedCategoryIds.length > 0) {
+      params.push(filters.includedCategoryIds);
+      categoryClauses.push(`t.category_id = ANY($${params.length}::int[])`);
+    }
+    if (filters.includeUncategorizedIncome) {
+      categoryClauses.push('(t.category_id IS NULL AND t.amount > 0)');
+    }
+    if (filters.includeUncategorizedExpense) {
+      categoryClauses.push('(t.category_id IS NULL AND t.amount < 0)');
+    }
+    clauses.push(categoryClauses.length > 0 ? `(${categoryClauses.join(' OR ')})` : 'FALSE');
+  }
+
+  return { whereSql: `WHERE ${clauses.join(' AND ')}`, params };
+}
+```
+
+- [ ] **Step 4: Implement data shaping helpers**
+
+Add these functions to `lib/analytics/transaction-analysis.ts`:
+
+```ts
+function addPercentages(
+  rows: Array<Omit<AnalysisCategoryBreakdown, 'percentage'>>
+): AnalysisCategoryBreakdown[] {
+  const total = rows.reduce((sum, row) => sum + Number.parseFloat(row.amount), 0);
+  return rows.map((row) => ({
+    ...row,
+    percentage: total > 0 ? (Number.parseFloat(row.amount) / total) * 100 : 0,
+  }));
+}
+
+export function groupStackedTrendRows(rows: RawStackedTrendRow[]): StackedTrendPoint[] {
+  const totals = new Map<string, { path: string; total: number }>();
+  for (const row of rows) {
+    const amount = Number.parseFloat(row.amount);
+    const current = totals.get(row.category_key) ?? { path: row.category_path, total: 0 };
+    totals.set(row.category_key, { path: row.category_path, total: current.total + amount });
+  }
+
+  const topKeys = new Set(
+    Array.from(totals.entries())
+      .sort((a, b) => b[1].total - a[1].total)
+      .slice(0, 10)
+      .map(([key]) => key)
+  );
+
+  const byPeriod = new Map<string, StackedTrendPoint>();
+  for (const row of rows) {
+    const point = byPeriod.get(row.period) ?? { period: row.period };
+    const stackKey = topKeys.has(row.category_key) ? row.category_path : 'Other';
+    point[stackKey] = Number(point[stackKey] ?? 0) + Number.parseFloat(row.amount);
+    byPeriod.set(row.period, point);
+  }
+
+  return Array.from(byPeriod.values()).sort((a, b) =>
+    String(a.period).localeCompare(String(b.period))
+  );
+}
+
+function groupCategoryTrendRows(rows: RawCategoryTrendRow[]): CategoryTrendRow[] {
+  const grouped = new Map<string, CategoryTrendRow>();
+  for (const row of rows) {
+    const existing = grouped.get(row.category_key) ?? {
+      categoryKey: row.category_key,
+      categoryType: row.category_type,
+      categoryPath: row.category_path,
+      total: 0,
+      periods: {},
+    };
+    const amount = Number.parseFloat(row.amount);
+    existing.periods[row.period] = (existing.periods[row.period] ?? 0) + amount;
+    existing.total += amount;
+    grouped.set(row.category_key, existing);
+  }
+
+  return Array.from(grouped.values()).sort((a, b) => b.total - a.total);
+}
+```
+
+- [ ] **Step 5: Implement query function**
+
+Add `getTransactionAnalysis` to `lib/analytics/transaction-analysis.ts`:
+
+```ts
+export async function getTransactionAnalysis(
+  filters: AnalysisFilters
+): Promise<TransactionAnalysisData> {
+  if (filters.hasInvalidDateRange) {
+    return emptyTransactionAnalysis();
+  }
+
+  const { whereSql, params } = buildAnalysisWhereClause(filters);
+  const periodSql = periodExpression(filters.resolvedGrouping);
+  const categoryHierarchy = `
+    WITH RECURSIVE category_hierarchy AS (
+      SELECT id, name, parent_id, category_type, name::varchar as full_path
+      FROM categories
+      WHERE parent_id IS NULL
+      UNION ALL
+      SELECT c.id, c.name, c.parent_id, c.category_type, ch.full_path || ' > ' || c.name
+      FROM categories c
+      INNER JOIN category_hierarchy ch ON c.parent_id = ch.id
+    )`;
+
+  const summary = await queryOne<AnalysisSummary>(
+    `${categoryHierarchy}
+     SELECT
+       COALESCE(SUM(CASE
+         WHEN ch.category_type = 'income' THEN t.amount
+         WHEN t.category_id IS NULL AND t.amount > 0 THEN t.amount
+         ELSE 0
+       END), 0)::decimal(15,2) as income,
+       COALESCE(ABS(SUM(CASE
+         WHEN ch.category_type = 'expense' THEN t.amount
+         WHEN t.category_id IS NULL AND t.amount < 0 THEN t.amount
+         ELSE 0
+       END)), 0)::decimal(15,2) as expenses
+     FROM transactions t
+     LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+     ${whereSql}`,
+    params
+  );
+
+  const incomeExpenseTrend = await queryMany<IncomeExpenseTrendPoint>(
+    `${categoryHierarchy}
+     SELECT
+       ${periodSql} as period,
+       COALESCE(SUM(CASE
+         WHEN ch.category_type = 'income' THEN t.amount
+         WHEN t.category_id IS NULL AND t.amount > 0 THEN t.amount
+         ELSE 0
+       END), 0)::decimal(15,2) as income,
+       COALESCE(ABS(SUM(CASE
+         WHEN ch.category_type = 'expense' THEN t.amount
+         WHEN t.category_id IS NULL AND t.amount < 0 THEN t.amount
+         ELSE 0
+       END)), 0)::decimal(15,2) as expenses
+     FROM transactions t
+     LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+     ${whereSql}
+     GROUP BY period
+     ORDER BY period ASC`,
+    params
+  );
+
+  const breakdownSql = (categoryType: 'income' | 'expense') => `${categoryHierarchy}
+     SELECT
+       t.category_id,
+       COALESCE(ch.name, 'Uncategorized') as category_name,
+       COALESCE(ch.full_path, 'Uncategorized') as category_path,
+       ABS(SUM(t.amount))::decimal(15,2) as amount
+     FROM transactions t
+     LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+     ${whereSql}
+       AND (ch.category_type = '${categoryType}' OR (t.category_id IS NULL AND ${categoryType === 'income' ? 't.amount > 0' : 't.amount < 0'}))
+     GROUP BY t.category_id, ch.name, ch.full_path
+     HAVING ABS(SUM(t.amount)) > 0
+     ORDER BY amount DESC`;
+
+  const [rawExpenseBreakdown, rawIncomeBreakdown, rawExpenseStacked, rawIncomeStacked, rawTrendRows] =
+    await Promise.all([
+      queryMany<Omit<AnalysisCategoryBreakdown, 'percentage'>>(breakdownSql('expense'), params),
+      queryMany<Omit<AnalysisCategoryBreakdown, 'percentage'>>(breakdownSql('income'), params),
+      queryMany<RawStackedTrendRow>(
+        `${categoryHierarchy}
+         SELECT ${periodSql} as period,
+                COALESCE(t.category_id::text, 'uncategorized-expense') as category_key,
+                COALESCE(ch.full_path, 'Uncategorized') as category_path,
+                ABS(SUM(t.amount))::decimal(15,2) as amount
+         FROM transactions t
+         LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+         ${whereSql}
+           AND (ch.category_type = 'expense' OR (t.category_id IS NULL AND t.amount < 0))
+         GROUP BY period, category_key, category_path
+         HAVING ABS(SUM(t.amount)) > 0
+         ORDER BY period ASC`,
+        params
+      ),
+      queryMany<RawStackedTrendRow>(
+        `${categoryHierarchy}
+         SELECT ${periodSql} as period,
+                COALESCE(t.category_id::text, 'uncategorized-income') as category_key,
+                COALESCE(ch.full_path, 'Uncategorized') as category_path,
+                ABS(SUM(t.amount))::decimal(15,2) as amount
+         FROM transactions t
+         LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+         ${whereSql}
+           AND (ch.category_type = 'income' OR (t.category_id IS NULL AND t.amount > 0))
+         GROUP BY period, category_key, category_path
+         HAVING ABS(SUM(t.amount)) > 0
+         ORDER BY period ASC`,
+        params
+      ),
+      queryMany<RawCategoryTrendRow>(
+        `${categoryHierarchy}
+         SELECT COALESCE(t.category_id::text, CASE WHEN t.amount > 0 THEN 'uncategorized-income' ELSE 'uncategorized-expense' END) as category_key,
+                COALESCE(ch.category_type, CASE WHEN t.amount > 0 THEN 'income' ELSE 'expense' END) as category_type,
+                COALESCE(ch.full_path, 'Uncategorized') as category_path,
+                ${periodSql} as period,
+                ABS(SUM(t.amount))::decimal(15,2) as amount
+         FROM transactions t
+         LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+         ${whereSql}
+         GROUP BY category_key, category_type, category_path, period
+         HAVING ABS(SUM(t.amount)) > 0
+         ORDER BY category_path ASC, period ASC`,
+        params
+      ),
+    ]);
+
+  return {
+    summary: summary ?? { income: '0.00', expenses: '0.00' },
+    incomeExpenseTrend,
+    expenseBreakdown: addPercentages(rawExpenseBreakdown),
+    incomeBreakdown: addPercentages(rawIncomeBreakdown),
+    expenseStackedTrend: groupStackedTrendRows(rawExpenseStacked),
+    incomeStackedTrend: groupStackedTrendRows(rawIncomeStacked),
+    categoryTrendRows: groupCategoryTrendRows(rawTrendRows),
+  };
+}
+```
+
+- [ ] **Step 6: Run analytics tests and verify they pass**
+
+Run:
+
+```bash
+npm test -- --run __tests__/lib/analytics/transaction-analysis.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit analytics work**
+
+```bash
+git add lib/analytics/transaction-analysis.ts __tests__/lib/analytics/transaction-analysis.test.ts
+git commit -m "feat: add transaction analysis analytics"
+```
+
+## Task 3: Analysis Display Components
+
+**Files:**
+
+- Create: `components/analysis/analysis-summary-cards.tsx`
+- Create: `components/analysis/income-expense-trend-chart.tsx`
+- Create: `components/analysis/category-breakdown-chart.tsx`
+- Create: `components/analysis/category-stacked-trend-chart.tsx`
+- Create: `components/analysis/category-trend-table.tsx`
+
+- [ ] **Step 1: Create summary card component**
+
+Create `components/analysis/analysis-summary-cards.tsx`:
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface AnalysisSummaryCardsProps {
+  income: string;
+  expenses: string;
+  locale: string;
+  labels: {
+    income: string;
+    expenses: string;
+  };
+}
+
+function formatCurrency(amount: string, locale: string) {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: locale === 'pt-BR' ? 'BRL' : 'USD',
+  }).format(Number.parseFloat(amount));
+}
+
+export function AnalysisSummaryCards({
+  income,
+  expenses,
+  locale,
+  labels,
+}: AnalysisSummaryCardsProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {labels.income}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold text-green-600">
+            {formatCurrency(income, locale)}
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {labels.expenses}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold text-red-600">
+            {formatCurrency(expenses, locale)}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create grouped trend chart**
+
+Create `components/analysis/income-expense-trend-chart.tsx`:
+
+```tsx
+'use client';
+
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { IncomeExpenseTrendPoint } from '@/lib/analytics/transaction-analysis';
+
+interface IncomeExpenseTrendChartProps {
+  data: IncomeExpenseTrendPoint[];
+  title: string;
+  emptyText: string;
+}
+
+export function IncomeExpenseTrendChart({
+  data,
+  title,
+  emptyText,
+}: IncomeExpenseTrendChartProps) {
+  const chartData = data.map((point) => ({
+    period: point.period,
+    Income: Number.parseFloat(point.income),
+    Expenses: Number.parseFloat(point.expenses),
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {chartData.length === 0 ? (
+          <div className="flex h-[320px] items-center justify-center text-sm text-muted-foreground">
+            {emptyText}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="period" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="Income" fill="#22c55e" />
+              <Bar dataKey="Expenses" fill="#ef4444" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 3: Create breakdown chart**
+
+Create `components/analysis/category-breakdown-chart.tsx`:
+
+```tsx
+'use client';
+
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AnalysisCategoryBreakdown } from '@/lib/analytics/transaction-analysis';
+
+interface CategoryBreakdownChartProps {
+  data: AnalysisCategoryBreakdown[];
+  title: string;
+  emptyText: string;
+  color: string;
+}
+
+export function CategoryBreakdownChart({
+  data,
+  title,
+  emptyText,
+  color,
+}: CategoryBreakdownChartProps) {
+  const chartData = data.map((row) => ({
+    category: row.category_path,
+    amount: Number.parseFloat(row.amount),
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {chartData.length === 0 ? (
+          <div className="flex h-[320px] items-center justify-center text-sm text-muted-foreground">
+            {emptyText}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart data={chartData} layout="vertical" margin={{ left: 24 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis type="number" />
+              <YAxis dataKey="category" type="category" width={120} />
+              <Tooltip />
+              <Bar dataKey="amount" fill={color} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Create stacked trend chart**
+
+Create `components/analysis/category-stacked-trend-chart.tsx`:
+
+```tsx
+'use client';
+
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { StackedTrendPoint } from '@/lib/analytics/transaction-analysis';
+
+interface CategoryStackedTrendChartProps {
+  data: StackedTrendPoint[];
+  title: string;
+  emptyText: string;
+}
+
+const COLORS = ['#2563eb', '#16a34a', '#dc2626', '#9333ea', '#ea580c', '#0891b2', '#4f46e5', '#65a30d', '#be123c', '#0f766e', '#6b7280'];
+
+function stackKeys(data: StackedTrendPoint[]) {
+  return Array.from(
+    new Set(
+      data.flatMap((point) => Object.keys(point).filter((key) => key !== 'period'))
+    )
+  );
+}
+
+export function CategoryStackedTrendChart({
+  data,
+  title,
+  emptyText,
+}: CategoryStackedTrendChartProps) {
+  const keys = stackKeys(data);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 || keys.length === 0 ? (
+          <div className="flex h-[320px] items-center justify-center text-sm text-muted-foreground">
+            {emptyText}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="period" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              {keys.map((key, index) => (
+                <Bar key={key} dataKey={key} stackId="category" fill={COLORS[index % COLORS.length]} />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 5: Create category trend table**
+
+Create `components/analysis/category-trend-table.tsx`:
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { CategoryTrendRow } from '@/lib/analytics/transaction-analysis';
+
+interface CategoryTrendTableProps {
+  rows: CategoryTrendRow[];
+  periods: string[];
+  title: string;
+  emptyText: string;
+  totalLabel: string;
+  categoryLabel: string;
+  typeLabel: string;
+  locale: string;
+}
+
+function formatCurrency(amount: number, locale: string) {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: locale === 'pt-BR' ? 'BRL' : 'USD',
+  }).format(amount);
+}
+
+export function CategoryTrendTable({
+  rows,
+  periods,
+  title,
+  emptyText,
+  totalLabel,
+  categoryLabel,
+  typeLabel,
+  locale,
+}: CategoryTrendTableProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <div className="py-12 text-center text-sm text-muted-foreground">{emptyText}</div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{categoryLabel}</TableHead>
+                <TableHead>{typeLabel}</TableHead>
+                <TableHead className="text-right">{totalLabel}</TableHead>
+                {periods.map((period) => (
+                  <TableHead key={period} className="text-right">
+                    {period}
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.categoryKey}>
+                  <TableCell className="font-medium">{row.categoryPath}</TableCell>
+                  <TableCell className="capitalize">{row.categoryType}</TableCell>
+                  <TableCell className="text-right">{formatCurrency(row.total, locale)}</TableCell>
+                  {periods.map((period) => (
+                    <TableCell key={period} className="text-right">
+                      {formatCurrency(row.periods[period] ?? 0, locale)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 6: Run TypeScript-adjacent validation through lint**
+
+Run:
+
+```bash
+npm run lint
+```
+
+Expected: PASS for the new components. Resolve lint diagnostics only in files from this task, then rerun `npm run lint` until it passes.
+
+- [ ] **Step 7: Commit display components**
+
+```bash
+git add components/analysis
+git commit -m "feat: add analysis display components"
+```
+
+## Task 4: Category Filter Tree And Client Filter UI
+
+**Files:**
+
+- Create: `components/analysis/analysis-category-filter.tsx`
+- Create: `__tests__/components/analysis/analysis-category-filter.test.tsx`
+- Create: `app/(dashboard)/analysis/client.tsx`
+- Create: `__tests__/app/analysis-client.test.tsx`
+
+- [ ] **Step 1: Write category filter tests**
+
+Create `__tests__/components/analysis/analysis-category-filter.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AnalysisCategoryFilter } from '@/components/analysis/analysis-category-filter';
+import { CategoryWithPath } from '@/lib/db/categories';
+
+const categories: CategoryWithPath[] = [
+  { id: 1, name: 'Housing', parent_id: null, category_type: 'expense', depth: 1, created_at: new Date('2026-01-01'), path: 'Housing' },
+  { id: 2, name: 'Rent', parent_id: 1, category_type: 'expense', depth: 2, created_at: new Date('2026-01-01'), path: 'Housing > Rent' },
+  { id: 3, name: 'Utilities', parent_id: 1, category_type: 'expense', depth: 2, created_at: new Date('2026-01-01'), path: 'Housing > Utilities' },
+  { id: 4, name: 'Salary', parent_id: null, category_type: 'income', depth: 1, created_at: new Date('2026-01-01'), path: 'Salary' },
+];
+
+describe('AnalysisCategoryFilter', () => {
+  it('toggles descendants when a parent category changes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <AnalysisCategoryFilter
+        categories={categories}
+        selectedCategoryIds={[1, 2, 3, 4]}
+        includeUncategorizedIncome
+        includeUncategorizedExpense
+        labels={{
+          title: 'Categories',
+          income: 'Income',
+          expense: 'Expenses',
+          uncategorizedIncome: 'Uncategorized income',
+          uncategorizedExpense: 'Uncategorized expenses',
+        }}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Housing' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      selectedCategoryIds: [4],
+      includeUncategorizedIncome: true,
+      includeUncategorizedExpense: true,
+    });
+  });
+
+  it('allows child overrides after parent state changes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <AnalysisCategoryFilter
+        categories={categories}
+        selectedCategoryIds={[4]}
+        includeUncategorizedIncome
+        includeUncategorizedExpense
+        labels={{
+          title: 'Categories',
+          income: 'Income',
+          expense: 'Expenses',
+          uncategorizedIncome: 'Uncategorized income',
+          uncategorizedExpense: 'Uncategorized expenses',
+        }}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Rent' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      selectedCategoryIds: [2, 4],
+      includeUncategorizedIncome: true,
+      includeUncategorizedExpense: true,
+    });
+  });
+
+  it('toggles uncategorized flags independently', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <AnalysisCategoryFilter
+        categories={categories}
+        selectedCategoryIds={[1, 2, 3, 4]}
+        includeUncategorizedIncome
+        includeUncategorizedExpense
+        labels={{
+          title: 'Categories',
+          income: 'Income',
+          expense: 'Expenses',
+          uncategorizedIncome: 'Uncategorized income',
+          uncategorizedExpense: 'Uncategorized expenses',
+        }}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Uncategorized income' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      selectedCategoryIds: [1, 2, 3, 4],
+      includeUncategorizedIncome: false,
+      includeUncategorizedExpense: true,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run category filter tests and verify they fail**
+
+Run:
+
+```bash
+npm test -- --run __tests__/components/analysis/analysis-category-filter.test.tsx
+```
+
+Expected: FAIL because `AnalysisCategoryFilter` does not exist.
+
+- [ ] **Step 3: Implement category filter component**
+
+Create `components/analysis/analysis-category-filter.tsx`:
+
+```tsx
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CategoryWithPath } from '@/lib/db/categories';
+
+interface Labels {
+  title: string;
+  income: string;
+  expense: string;
+  uncategorizedIncome: string;
+  uncategorizedExpense: string;
+}
+
+interface AnalysisCategoryFilterProps {
+  categories: CategoryWithPath[];
+  selectedCategoryIds: number[];
+  includeUncategorizedIncome: boolean;
+  includeUncategorizedExpense: boolean;
+  labels: Labels;
+  onChange: (next: {
+    selectedCategoryIds: number[];
+    includeUncategorizedIncome: boolean;
+    includeUncategorizedExpense: boolean;
+  }) => void;
+}
+
+function descendantIds(category: CategoryWithPath, categories: CategoryWithPath[]) {
+  const ids = [category.id];
+  const children = categories.filter((candidate) => candidate.parent_id === category.id);
+  for (const child of children) {
+    ids.push(...descendantIds(child, categories));
+  }
+  return ids;
+}
+
+function branchState(category: CategoryWithPath, categories: CategoryWithPath[], selected: Set<number>) {
+  const ids = descendantIds(category, categories);
+  const selectedCount = ids.filter((id) => selected.has(id)).length;
+  if (selectedCount === 0) return false;
+  if (selectedCount === ids.length) return true;
+  return 'mixed' as const;
+}
+
+function CategoryRow({
+  category,
+  categories,
+  selected,
+  onToggle,
+}: {
+  category: CategoryWithPath;
+  categories: CategoryWithPath[];
+  selected: Set<number>;
+  onToggle: (category: CategoryWithPath) => void;
+}) {
+  const state = branchState(category, categories, selected);
+
+  return (
+    <div style={{ paddingLeft: `${(category.depth - 1) * 16}px` }}>
+      <label className="flex items-center gap-2 py-1 text-sm">
+        <input
+          type="checkbox"
+          checked={state === true}
+          ref={(input) => {
+            if (input) input.indeterminate = state === 'mixed';
+          }}
+          onChange={() => onToggle(category)}
+        />
+        <span>{category.name}</span>
+      </label>
+    </div>
+  );
+}
+
+export function AnalysisCategoryFilter({
+  categories,
+  selectedCategoryIds,
+  includeUncategorizedIncome,
+  includeUncategorizedExpense,
+  labels,
+  onChange,
+}: AnalysisCategoryFilterProps) {
+  const selected = new Set(selectedCategoryIds);
+
+  const toggleCategory = (category: CategoryWithPath) => {
+    const ids = descendantIds(category, categories);
+    const allSelected = ids.every((id) => selected.has(id));
+    const next = new Set(selected);
+    for (const id of ids) {
+      if (allSelected) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+    }
+    onChange({
+      selectedCategoryIds: Array.from(next).sort((a, b) => a - b),
+      includeUncategorizedIncome,
+      includeUncategorizedExpense,
+    });
+  };
+
+  const renderGroup = (type: 'income' | 'expense', title: string) => (
+    <div className="space-y-2">
+      <h3 className="font-medium">{title}</h3>
+      {categories
+        .filter((category) => category.category_type === type)
+        .sort((a, b) => a.path.localeCompare(b.path))
+        .map((category) => (
+          <CategoryRow
+            key={category.id}
+            category={category}
+            categories={categories}
+            selected={selected}
+            onToggle={toggleCategory}
+          />
+        ))}
+      <label className="flex items-center gap-2 py-1 text-sm">
+        <input
+          type="checkbox"
+          checked={type === 'income' ? includeUncategorizedIncome : includeUncategorizedExpense}
+          onChange={() =>
+            onChange({
+              selectedCategoryIds,
+              includeUncategorizedIncome:
+                type === 'income' ? !includeUncategorizedIncome : includeUncategorizedIncome,
+              includeUncategorizedExpense:
+                type === 'expense' ? !includeUncategorizedExpense : includeUncategorizedExpense,
+            })
+          }
+        />
+        <span>{type === 'income' ? labels.uncategorizedIncome : labels.uncategorizedExpense}</span>
+      </label>
+    </div>
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{labels.title}</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-6 md:grid-cols-2">
+        {renderGroup('expense', labels.expense)}
+        {renderGroup('income', labels.income)}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Run category filter tests and verify they pass**
+
+Run:
+
+```bash
+npm test -- --run __tests__/components/analysis/analysis-category-filter.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write client tests**
+
+Create `__tests__/app/analysis-client.test.tsx`:
+
+```tsx
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NextIntlClientProvider } from 'next-intl';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnalysisClient } from '@/app/(dashboard)/analysis/client';
+import enMessages from '@/messages/en.json';
+import { Account } from '@/lib/db/types';
+import { CategoryWithPath } from '@/lib/db/categories';
+import { AnalysisFilters } from '@/lib/analysis/filters';
+import { TransactionAnalysisData } from '@/lib/analytics/transaction-analysis';
+
+vi.mock('@/components/analysis/income-expense-trend-chart', () => ({
+  IncomeExpenseTrendChart: () => <div data-testid="income-expense-chart" />,
+}));
+vi.mock('@/components/analysis/category-breakdown-chart', () => ({
+  CategoryBreakdownChart: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+vi.mock('@/components/analysis/category-stacked-trend-chart', () => ({
+  CategoryStackedTrendChart: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+vi.mock('@/components/analysis/category-trend-table', () => ({
+  CategoryTrendTable: () => <div data-testid="trend-table" />,
+}));
+
+describe('AnalysisClient', () => {
+  let push: ReturnType<typeof vi.fn>;
+  const accounts: Account[] = [
+    { id: 1, name: 'Checking', created_at: new Date('2026-01-01') },
+    { id: 2, name: 'Savings', created_at: new Date('2026-01-01') },
+  ];
+  const categories: CategoryWithPath[] = [
+    { id: 4, name: 'Salary', parent_id: null, category_type: 'income', depth: 1, created_at: new Date('2026-01-01'), path: 'Salary' },
+    { id: 7, name: 'Rent', parent_id: null, category_type: 'expense', depth: 1, created_at: new Date('2026-01-01'), path: 'Rent' },
+  ];
+  const filters: AnalysisFilters = {
+    preset: 'last-3-months',
+    from: '2026-02-10',
+    to: '2026-05-10',
+    grouping: 'adaptive',
+    resolvedGrouping: 'weekly',
+    includedCategoryIds: [4, 7],
+    hasCategoryFilter: false,
+    includeUncategorizedIncome: true,
+    includeUncategorizedExpense: true,
+    hasInvalidDateRange: false,
+  };
+  const data: TransactionAnalysisData = {
+    summary: { income: '1000.00', expenses: '450.00' },
+    incomeExpenseTrend: [],
+    expenseBreakdown: [],
+    incomeBreakdown: [],
+    expenseStackedTrend: [],
+    incomeStackedTrend: [],
+    categoryTrendRows: [],
+  };
+
+  beforeEach(() => {
+    Element.prototype.hasPointerCapture ??= vi.fn(() => false);
+    Element.prototype.setPointerCapture ??= vi.fn();
+    Element.prototype.releasePointerCapture ??= vi.fn();
+    Element.prototype.scrollIntoView ??= vi.fn();
+    push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({
+      push,
+      replace: vi.fn(),
+      refresh: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      prefetch: vi.fn(),
+    } as ReturnType<typeof useRouter>);
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams('lang=en') as ReturnType<typeof useSearchParams>
+    );
+  });
+
+  function renderClient() {
+    return render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <AnalysisClient accounts={accounts} categories={categories} filters={filters} data={data} lang="en" />
+      </NextIntlClientProvider>
+    );
+  }
+
+  it('renders analysis sections', () => {
+    renderClient();
+
+    expect(screen.getByRole('heading', { name: 'Analysis' })).toBeInTheDocument();
+    expect(screen.getByText('Income')).toBeInTheDocument();
+    expect(screen.getByText('Expenses')).toBeInTheDocument();
+    expect(screen.getByTestId('income-expense-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('trend-table')).toBeInTheDocument();
+  });
+
+  it('updates the URL when account changes', async () => {
+    const user = userEvent.setup();
+    renderClient();
+
+    await user.click(screen.getByRole('combobox', { name: 'Account' }));
+    await user.click(await screen.findByRole('option', { name: 'Savings' }));
+
+    const pushedUrl = push.mock.calls.at(-1)?.[0] as string;
+    expect(pushedUrl).toContain('accountId=2');
+    expect(pushedUrl).toContain('lang=en');
+  });
+
+  it('clears filters back to defaults', async () => {
+    const user = userEvent.setup();
+    renderClient();
+
+    await user.click(screen.getByRole('button', { name: 'Reset' }));
+
+    const pushedUrl = push.mock.calls.at(-1)?.[0] as string;
+    expect(pushedUrl).toBe('/analysis?lang=en');
+  });
+});
+```
+
+- [ ] **Step 6: Implement client component**
+
+Create `app/(dashboard)/analysis/client.tsx` with URL-driven controls and layout:
+
+```tsx
+'use client';
+
+import { useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { AnalysisCategoryFilter } from '@/components/analysis/analysis-category-filter';
+import { AnalysisSummaryCards } from '@/components/analysis/analysis-summary-cards';
+import { CategoryBreakdownChart } from '@/components/analysis/category-breakdown-chart';
+import { CategoryStackedTrendChart } from '@/components/analysis/category-stacked-trend-chart';
+import { CategoryTrendTable } from '@/components/analysis/category-trend-table';
+import { IncomeExpenseTrendChart } from '@/components/analysis/income-expense-trend-chart';
+import { Account } from '@/lib/db/types';
+import { CategoryWithPath } from '@/lib/db/categories';
+import { AnalysisDatePreset, AnalysisFilters, AnalysisGrouping } from '@/lib/analysis/filters';
+import { TransactionAnalysisData } from '@/lib/analytics/transaction-analysis';
+
+interface AnalysisClientProps {
+  accounts: Account[];
+  categories: CategoryWithPath[];
+  filters: AnalysisFilters;
+  data: TransactionAnalysisData;
+  lang: string;
+}
+
+function setOrDelete(params: URLSearchParams, key: string, value: string | undefined) {
+  if (value) params.set(key, value);
+  else params.delete(key);
+}
+
+export function AnalysisClient({ accounts, categories, filters, data, lang }: AnalysisClientProps) {
+  const t = useTranslations('analysis');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const periods = useMemo(
+    () => Array.from(new Set(data.incomeExpenseTrend.map((point) => point.period))),
+    [data.incomeExpenseTrend]
+  );
+
+  const pushParams = (updates: Record<string, string | undefined>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (!params.get('lang')) params.set('lang', lang);
+    for (const [key, value] of Object.entries(updates)) {
+      setOrDelete(params, key, value);
+    }
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  const selectedCategoryIds = filters.hasCategoryFilter
+    ? filters.includedCategoryIds
+    : categories.map((category) => category.id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-3xl font-bold">{t('title')}</h2>
+        <p className="text-muted-foreground">{t('description')}</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('filters')}</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2 lg:grid-cols-6">
+          <div className="space-y-2">
+            <Label>{t('dateRange')}</Label>
+            <Select value={filters.preset} onValueChange={(value) => pushParams({ preset: value as AnalysisDatePreset })}>
+              <SelectTrigger aria-label={t('dateRange')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="this-month">{t('presets.thisMonth')}</SelectItem>
+                <SelectItem value="last-month">{t('presets.lastMonth')}</SelectItem>
+                <SelectItem value="last-3-months">{t('presets.last3Months')}</SelectItem>
+                <SelectItem value="last-90-days">{t('presets.last90Days')}</SelectItem>
+                <SelectItem value="this-year">{t('presets.thisYear')}</SelectItem>
+                <SelectItem value="ytd">{t('presets.ytd')}</SelectItem>
+                <SelectItem value="last-year">{t('presets.lastYear')}</SelectItem>
+                <SelectItem value="custom">{t('presets.custom')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="analysis-from">{t('from')}</Label>
+            <Input id="analysis-from" type="date" value={filters.from} onChange={(event) => pushParams({ preset: 'custom', from: event.currentTarget.value })} />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="analysis-to">{t('to')}</Label>
+            <Input id="analysis-to" type="date" value={filters.to} onChange={(event) => pushParams({ preset: 'custom', to: event.currentTarget.value })} />
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('account')}</Label>
+            <Select value={filters.accountId?.toString() ?? 'all'} onValueChange={(value) => pushParams({ accountId: value === 'all' ? undefined : value })}>
+              <SelectTrigger aria-label={t('account')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t('allAccounts')}</SelectItem>
+                {accounts.map((account) => (
+                  <SelectItem key={account.id} value={account.id.toString()}>{account.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('grouping')}</Label>
+            <Select value={filters.grouping} onValueChange={(value) => pushParams({ grouping: value as AnalysisGrouping })}>
+              <SelectTrigger aria-label={t('grouping')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="adaptive">{t('groupings.adaptive')}</SelectItem>
+                <SelectItem value="daily">{t('groupings.daily')}</SelectItem>
+                <SelectItem value="weekly">{t('groupings.weekly')}</SelectItem>
+                <SelectItem value="monthly">{t('groupings.monthly')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-end">
+            <Button type="button" variant="outline" onClick={() => router.push(`/analysis?lang=${lang}`)}>
+              {t('reset')}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {filters.hasInvalidDateRange ? (
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            {t('invalidDateRange')}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <AnalysisCategoryFilter
+        categories={categories}
+        selectedCategoryIds={selectedCategoryIds}
+        includeUncategorizedIncome={filters.includeUncategorizedIncome}
+        includeUncategorizedExpense={filters.includeUncategorizedExpense}
+        labels={{
+          title: t('categories'),
+          income: t('income'),
+          expense: t('expenses'),
+          uncategorizedIncome: t('uncategorizedIncome'),
+          uncategorizedExpense: t('uncategorizedExpense'),
+        }}
+        onChange={(next) =>
+          pushParams({
+            categories: next.selectedCategoryIds.join(','),
+            uncategorizedIncome: next.includeUncategorizedIncome ? undefined : '0',
+            uncategorizedExpense: next.includeUncategorizedExpense ? undefined : '0',
+          })
+        }
+      />
+
+      <AnalysisSummaryCards
+        income={data.summary.income}
+        expenses={data.summary.expenses}
+        locale={lang}
+        labels={{ income: t('income'), expenses: t('expenses') }}
+      />
+
+      <IncomeExpenseTrendChart data={data.incomeExpenseTrend} title={t('incomeVsExpensesTrend')} emptyText={t('empty')} />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <CategoryStackedTrendChart data={data.expenseStackedTrend} title={t('expenseStackedTrend')} emptyText={t('emptyExpenses')} />
+        <CategoryStackedTrendChart data={data.incomeStackedTrend} title={t('incomeStackedTrend')} emptyText={t('emptyIncome')} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <CategoryBreakdownChart data={data.expenseBreakdown} title={t('expenseBreakdown')} emptyText={t('emptyExpenses')} color="#ef4444" />
+        <CategoryBreakdownChart data={data.incomeBreakdown} title={t('incomeBreakdown')} emptyText={t('emptyIncome')} color="#22c55e" />
+      </div>
+
+      <CategoryTrendTable
+        rows={data.categoryTrendRows}
+        periods={periods}
+        title={t('categoryTrendTable')}
+        emptyText={t('empty')}
+        totalLabel={t('total')}
+        categoryLabel={t('category')}
+        typeLabel={t('type')}
+        locale={lang}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Run client tests and fix compile issues**
+
+Run:
+
+```bash
+npm test -- --run __tests__/components/analysis/analysis-category-filter.test.tsx __tests__/app/analysis-client.test.tsx
+```
+
+Expected: PASS. Resolve import and type diagnostics only in files from this task, then rerun the same command until it passes.
+
+- [ ] **Step 8: Commit category and client UI**
+
+```bash
+git add components/analysis/analysis-category-filter.tsx __tests__/components/analysis/analysis-category-filter.test.tsx 'app/(dashboard)/analysis/client.tsx' __tests__/app/analysis-client.test.tsx
+git commit -m "feat: add analysis filter interface"
+```
+
+## Task 5: Server Route, Navigation, And Translations
+
+**Files:**
+
+- Create: `app/(dashboard)/analysis/page.tsx`
+- Modify: `components/dashboard/nav.tsx`
+- Modify: `messages/en.json`
+- Modify: `messages/pt-BR.json`
+
+- [ ] **Step 1: Implement server page**
+
+Create `app/(dashboard)/analysis/page.tsx`:
+
+```tsx
+import { AnalysisClient } from './client';
+import { getTransactionAnalysis } from '@/lib/analytics/transaction-analysis';
+import { parseAnalysisFilters } from '@/lib/analysis/filters';
+import { getAllAccounts } from '@/lib/db/accounts';
+import { getAllCategoriesWithPaths } from '@/lib/db/categories';
+import { getLangFromUrl } from '@/lib/i18n/utils';
+
+interface AnalysisPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function AnalysisPage({ searchParams }: AnalysisPageProps) {
+  const params = await searchParams;
+  const lang = await getLangFromUrl();
+  const accounts = await getAllAccounts();
+  const categories = await getAllCategoriesWithPaths();
+  const parsed = parseAnalysisFilters(params);
+  const validAccountIds = new Set(accounts.map((account) => account.id));
+  const validCategoryIds = new Set(categories.map((category) => category.id));
+  const filters = {
+    ...parsed,
+    accountId: parsed.accountId && validAccountIds.has(parsed.accountId) ? parsed.accountId : undefined,
+    includedCategoryIds: parsed.includedCategoryIds.filter((id) => validCategoryIds.has(id)),
+  };
+  const data = await getTransactionAnalysis(filters);
+
+  return (
+    <AnalysisClient
+      accounts={accounts}
+      categories={categories}
+      filters={filters}
+      data={data}
+      lang={lang}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Add navigation link**
+
+Modify `components/dashboard/nav.tsx` so `navLinks` includes Analysis after Transactions:
+
+```tsx
+  const navLinks = [
+    { href: `/?lang=${lang}`, label: t('dashboard') },
+    { href: `/accounts?lang=${lang}`, label: t('accounts') },
+    { href: `/transactions?lang=${lang}`, label: t('transactions') },
+    { href: `/analysis?lang=${lang}`, label: t('analysis') },
+  ];
+```
+
+- [ ] **Step 3: Add English translations**
+
+Modify `messages/en.json`:
+
+```json
+{
+  "nav": {
+    "analysis": "Analysis"
+  },
+  "analysis": {
+    "title": "Analysis",
+    "description": "Analyze income and expense trends across accounts and categories.",
+    "filters": "Filters",
+    "dateRange": "Date range",
+    "from": "From",
+    "to": "To",
+    "account": "Account",
+    "allAccounts": "All accounts",
+    "grouping": "Grouping",
+    "reset": "Reset",
+    "categories": "Categories",
+    "income": "Income",
+    "expenses": "Expenses",
+    "category": "Category",
+    "type": "Type",
+    "total": "Total",
+    "uncategorizedIncome": "Uncategorized income",
+    "uncategorizedExpense": "Uncategorized expenses",
+    "incomeVsExpensesTrend": "Income vs Expenses",
+    "expenseBreakdown": "Expense Breakdown",
+    "incomeBreakdown": "Income Breakdown",
+    "expenseStackedTrend": "Expense Categories Over Time",
+    "incomeStackedTrend": "Income Categories Over Time",
+    "categoryTrendTable": "Category Trend Table",
+    "empty": "No matching transactions for this selection.",
+    "emptyIncome": "No included income transactions for this selection.",
+    "emptyExpenses": "No included expense transactions for this selection.",
+    "invalidDateRange": "The selected start date is after the end date.",
+    "presets": {
+      "thisMonth": "This month",
+      "lastMonth": "Last month",
+      "last3Months": "Last 3 months",
+      "last90Days": "Last 90 days",
+      "thisYear": "This year",
+      "ytd": "YTD",
+      "lastYear": "Last year",
+      "custom": "Custom"
+    },
+    "groupings": {
+      "adaptive": "Adaptive",
+      "daily": "Daily",
+      "weekly": "Weekly",
+      "monthly": "Monthly"
+    }
+  }
+}
+```
+
+Insert the keys into the existing JSON objects instead of replacing the whole file.
+
+- [ ] **Step 4: Add Portuguese translations**
+
+Modify `messages/pt-BR.json`:
+
+```json
+{
+  "nav": {
+    "analysis": "Análise"
+  },
+  "analysis": {
+    "title": "Análise",
+    "description": "Analise tendências de receitas e despesas entre contas e categorias.",
+    "filters": "Filtros",
+    "dateRange": "Período",
+    "from": "De",
+    "to": "Até",
+    "account": "Conta",
+    "allAccounts": "Todas as contas",
+    "grouping": "Agrupamento",
+    "reset": "Redefinir",
+    "categories": "Categorias",
+    "income": "Receitas",
+    "expenses": "Despesas",
+    "category": "Categoria",
+    "type": "Tipo",
+    "total": "Total",
+    "uncategorizedIncome": "Receitas sem categoria",
+    "uncategorizedExpense": "Despesas sem categoria",
+    "incomeVsExpensesTrend": "Receitas vs Despesas",
+    "expenseBreakdown": "Detalhamento de Despesas",
+    "incomeBreakdown": "Detalhamento de Receitas",
+    "expenseStackedTrend": "Categorias de Despesas ao Longo do Tempo",
+    "incomeStackedTrend": "Categorias de Receitas ao Longo do Tempo",
+    "categoryTrendTable": "Tabela de Tendências por Categoria",
+    "empty": "Nenhuma transação corresponde a esta seleção.",
+    "emptyIncome": "Nenhuma receita incluída corresponde a esta seleção.",
+    "emptyExpenses": "Nenhuma despesa incluída corresponde a esta seleção.",
+    "invalidDateRange": "A data inicial selecionada é posterior à data final.",
+    "presets": {
+      "thisMonth": "Este mês",
+      "lastMonth": "Mês passado",
+      "last3Months": "Últimos 3 meses",
+      "last90Days": "Últimos 90 dias",
+      "thisYear": "Este ano",
+      "ytd": "Ano até hoje",
+      "lastYear": "Ano passado",
+      "custom": "Personalizado"
+    },
+    "groupings": {
+      "adaptive": "Adaptativo",
+      "daily": "Diário",
+      "weekly": "Semanal",
+      "monthly": "Mensal"
+    }
+  }
+}
+```
+
+Insert the keys into the existing JSON objects instead of replacing the whole file.
+
+- [ ] **Step 5: Run focused tests and lint**
+
+Run:
+
+```bash
+npm test -- --run __tests__/lib/analysis/filters.test.ts __tests__/lib/analytics/transaction-analysis.test.ts __tests__/components/analysis/analysis-category-filter.test.tsx __tests__/app/analysis-client.test.tsx
+npm run lint
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 6: Commit route, nav, and translations**
+
+```bash
+git add 'app/(dashboard)/analysis/page.tsx' components/dashboard/nav.tsx messages/en.json messages/pt-BR.json
+git commit -m "feat: add analysis route"
+```
+
+## Task 6: E2E Coverage And Final Verification
+
+**Files:**
+
+- Create: `e2e/11-analysis.spec.ts`
+
+- [ ] **Step 1: Write E2E tests**
+
+Create `e2e/11-analysis.spec.ts`:
+
+```ts
+import { test, expect } from './fixtures';
+import { login } from './helpers/auth';
+
+test.describe('Transaction Analysis', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.getByRole('link', { name: /analysis/i }).click();
+  });
+
+  test('renders the default analysis view', async ({ page }) => {
+    await expect(page).toHaveURL(/\/analysis/);
+    await expect(page.getByRole('heading', { name: /analysis/i, level: 2 })).toBeVisible();
+    await expect(page.getByText(/income vs expenses/i)).toBeVisible();
+    await expect(page.getByText(/expense categories over time/i)).toBeVisible();
+    await expect(page.getByText(/income categories over time/i)).toBeVisible();
+    await expect(page.getByText(/category trend table/i)).toBeVisible();
+  });
+
+  test('updates URL when filters change', async ({ page }) => {
+    await page.getByRole('combobox', { name: /grouping/i }).click();
+    await page.getByRole('option', { name: /monthly/i }).click();
+    await expect(page).toHaveURL(/grouping=monthly/);
+
+    await page.getByRole('combobox', { name: /date range/i }).click();
+    await page.getByRole('option', { name: /last year/i }).click();
+    await expect(page).toHaveURL(/preset=last-year/);
+  });
+
+  test('category toggles keep the page usable', async ({ page }) => {
+    await page.getByRole('checkbox', { name: /uncategorized income/i }).click();
+    await expect(page.getByText(/income vs expenses/i)).toBeVisible();
+    await expect(page.getByText(/category trend table/i)).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E analysis spec**
+
+Run:
+
+```bash
+npm run test:e2e -- e2e/11-analysis.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run complete local verification**
+
+Run:
+
+```bash
+npm run lint
+npm test -- --run
+npm run test:e2e
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 4: Commit E2E coverage**
+
+```bash
+git add e2e/11-analysis.spec.ts
+git commit -m "test: cover transaction analysis view"
+```
+
+## Final Checklist
+
+- [ ] `/analysis` is reachable from navigation.
+- [ ] Defaults are Last 3 months, all accounts, all categories, and Adaptive grouping.
+- [ ] Date preset, account, grouping, custom dates, and category selections update the URL.
+- [ ] Income and expense summary totals render.
+- [ ] Income vs expenses grouped bar chart renders.
+- [ ] Expense and income horizontal breakdown charts render.
+- [ ] Expense and income stacked trend charts render top 10 categories plus `Other`.
+- [ ] Category trend table renders totals and period columns.
+- [ ] Invalid date ranges render an invalid state.
+- [ ] English and Portuguese translations include all new labels.
+- [ ] `npm run lint` passes.
+- [ ] `npm test -- --run` passes.
+- [ ] `npm run test:e2e` passes.

--- a/docs/superpowers/specs/2026-05-10-transaction-analysis-design.md
+++ b/docs/superpowers/specs/2026-05-10-transaction-analysis-design.md
@@ -1,0 +1,316 @@
+# Transaction Analysis View Design
+
+> **Feature:** Create a transaction analysis view  
+> **Issue:** #49  
+> **Date:** 2026-05-10
+
+## Overview
+
+Add a dedicated authenticated `/analysis` page for selected-range income and expense analysis. The page helps users understand income and expense trends, category composition, and category totals across a chosen date range. It is inspired by YNAB-style reports, but v1 stays focused on actual transaction analysis rather than budgeting, forecasting, or period comparison.
+
+## Goals
+
+1. Show spending and income breakdowns for the selected date range.
+2. Show income and expense trends grouped by day, week, or month.
+3. Let users filter analysis by date range, account, and included categories.
+4. Support hierarchy-aware category inclusion for the existing 3-level category tree.
+5. Keep the analysis URL-driven so views can be refreshed, bookmarked, and shared.
+
+## Scope
+
+The default view uses:
+
+- Date range: Last 3 months
+- Accounts: All accounts
+- Categories: all income and expense categories included
+- Time grouping: Adaptive
+
+The page includes:
+
+- Selected-range total income
+- Selected-range total expenses
+- Income vs expenses trend chart over time
+- Expense category breakdown chart
+- Income category breakdown chart
+- Expense category stacked trend chart
+- Income category stacked trend chart
+- Category trend table
+
+Out of scope for v1:
+
+- Net cash flow summary
+- Savings rate or expense ratio
+- Previous-period deltas
+- Forecasting
+- Budget targets
+- Export
+- Saved report views
+
+## User Stories
+
+1. **Analyze a recent range** - A user opens Analysis and sees the last 3 months across all accounts.
+2. **Change the range** - A user selects a preset such as This month, Last month, This year, YTD, or Last year.
+3. **Use a custom range** - A user selects Custom and provides explicit start and end dates.
+4. **Filter by account** - A user narrows the analysis to one account or returns to all accounts.
+5. **Control time grouping** - A user keeps Adaptive grouping or explicitly chooses Daily, Weekly, or Monthly.
+6. **Include or exclude categories** - A user toggles parent categories, child categories, and uncategorized items to control what appears in the report.
+7. **Inspect category composition over time** - A user sees which top categories make up each period's income or expense totals.
+
+## Navigation
+
+Add `Analysis` to the main dashboard navigation between Transactions and Expense Reports. The route is protected by the existing `(dashboard)` layout, so no additional page-level auth guard is needed.
+
+## Filters
+
+Filters are stored in the URL query string.
+
+### Date Range
+
+Date preset options:
+
+- This month
+- Last month
+- Last 3 months
+- Last 90 days
+- This year
+- YTD
+- Last year
+- Custom
+
+`Last 3 months` is the default when no date parameters are present. `Custom` uses `from` and `to` date inputs. If Custom is selected but either date is missing or invalid, the parser falls back to Last 3 months.
+
+### Account
+
+The account filter defaults to all accounts. Selecting a specific account filters every chart, metric, and table to transactions for that account.
+
+Unknown account IDs are ignored and treated as all accounts.
+
+### Time Grouping
+
+Grouping options:
+
+- Adaptive
+- Daily
+- Weekly
+- Monthly
+
+Adaptive is the default and resolves to:
+
+- 45 days or less: Daily
+- 46-180 days: Weekly
+- More than 180 days: Monthly
+
+### Categories
+
+The category inclusion panel is hierarchy-aware and grouped by income and expense categories.
+
+Behavior:
+
+- A parent checkbox toggles all descendants.
+- Children can be individually overridden after a parent toggle.
+- A parent shows a mixed state when only some descendants are included.
+- Uncategorized transactions are represented as separate checkbox rows for income and expense analysis. Positive uncategorized transactions belong to income analysis; negative uncategorized transactions belong to expense analysis.
+- If no category include parameter is present, all categories and uncategorized transactions are included.
+- Unknown category IDs are ignored.
+
+The URL stores selected category IDs as an include list. This keeps the default compact while allowing a filtered view to be revisited.
+
+## Charts And Data
+
+### Summary Totals
+
+Two compact summary cards show total income and total expenses for the selected range after account and category filters are applied.
+
+### Income Vs Expenses Trend
+
+Chart type: grouped vertical bar chart.
+
+Each bar group represents one selected time bucket. The two bars show income and expenses for that bucket. This chart uses the selected grouping mode, or the resolved grouping mode when Adaptive is selected.
+
+### Expense Category Breakdown
+
+Chart type: horizontal bar chart.
+
+This chart sums all included expenses across the full selected date range, groups by category, and sorts by amount descending.
+
+### Income Category Breakdown
+
+Chart type: horizontal bar chart.
+
+This chart sums all included income across the full selected date range, groups by category, and sorts by amount descending.
+
+### Expense Category Stacked Trend
+
+Chart type: stacked vertical bar chart.
+
+Each bar represents one selected time bucket. Stack segments represent the top 10 expense categories by total amount across the full selected range after filters are applied. Remaining included expense categories are summed as `Other`.
+
+### Income Category Stacked Trend
+
+Chart type: stacked vertical bar chart.
+
+Each bar represents one selected time bucket. Stack segments represent the top 10 income categories by total amount across the full selected range after filters are applied. Remaining included income categories are summed as `Other`.
+
+### Category Trend Table
+
+The table shows one row per included category, with:
+
+- Category path
+- Category type
+- Total for the full selected range
+- One column per selected time bucket
+
+The table uses the same resolved grouping as the trend charts. It provides exact values to complement the charts.
+
+## Amount Rules
+
+- Categorized transactions are classified by `category_type`.
+- Income totals use the signed sum of transactions assigned to income categories, plus positive uncategorized transactions when included.
+- Expense totals use the absolute value of transactions assigned to expense categories, plus the absolute value of negative uncategorized transactions when included.
+- Uncategorized transactions are shown as `Uncategorized` and can be included or excluded independently for income and expense analysis.
+- Transactions whose sign does not match category type remain classified by category type, matching the current dashboard analytics behavior.
+- Percentages in breakdown charts are calculated against the included total for that income or expense type.
+- Top 10 categories for stacked charts are determined after all filters are applied.
+
+## Architecture
+
+### Server Page
+
+`app/(dashboard)/analysis/page.tsx`
+
+- Parses search params into typed analysis filters.
+- Fetches accounts and categories.
+- Validates account/category IDs against available records.
+- Fetches analysis data from the analytics module.
+- Passes filter state and data into the client component.
+
+### Client View
+
+`app/(dashboard)/analysis/client.tsx`
+
+- Renders the filter controls, category tree controls, summary cards, charts, and table.
+- Updates URL query parameters through App Router navigation.
+- Keeps local draft state for custom date inputs where needed.
+
+If the client file becomes too large, split reusable units into `components/analysis/*`, such as:
+
+- `analysis-filter-bar.tsx`
+- `analysis-category-filter.tsx`
+- `analysis-summary-cards.tsx`
+- `income-expense-trend-chart.tsx`
+- `category-breakdown-chart.tsx`
+- `category-stacked-trend-chart.tsx`
+- `category-trend-table.tsx`
+
+### Filter Parser
+
+`lib/analysis/filters.ts`
+
+Responsibilities:
+
+- Parse date presets, custom dates, account ID, category include IDs, and grouping.
+- Resolve presets to concrete `from` and `to` ISO dates.
+- Resolve Adaptive grouping to Daily, Weekly, or Monthly.
+- Detect reversed date ranges.
+- Ignore unknown enum values and malformed IDs.
+
+### Analytics Module
+
+`lib/analytics/transaction-analysis.ts`
+
+Responsibilities:
+
+- Build parameterized SQL for the selected date range, account, category include IDs, and grouping.
+- Return selected-range totals.
+- Return income vs expense trend buckets.
+- Return full-range category breakdowns.
+- Return top-10-plus-Other stacked trend datasets for income and expenses.
+- Return category trend table rows.
+
+The module should reuse existing query helpers from `lib/db/index.ts`.
+
+## UI Layout
+
+The page uses the existing dashboard visual language: quiet, utilitarian, and optimized for scanning.
+
+Top-to-bottom layout:
+
+1. Header with title `Analysis` and a short description.
+2. Filter card with date preset, custom dates, account, grouping, and reset action.
+3. Category inclusion panel with income and expense category trees.
+4. Summary row with Income and Expenses cards.
+5. Main trend section with the income vs expenses grouped bar chart.
+6. Composition trend section with expense and income stacked bar charts.
+7. Breakdown section with expense and income horizontal bar charts.
+8. Table section with category trend rows and period columns.
+
+Responsive behavior:
+
+- Desktop uses two-column grids for paired charts.
+- Mobile stacks filters, category controls, charts, and table vertically.
+- Charts use stable heights in responsive containers.
+- Long category labels are truncated in charts when needed, with exact paths available in the table.
+
+## Empty And Invalid States
+
+- No matching transactions: each chart and table area shows an empty state.
+- No selected expense categories: expense charts show an empty state.
+- No selected income categories: income charts show an empty state.
+- Reversed custom date range: page shows an invalid date range state and does not query misleading analysis data.
+- Database or query errors fall through to the existing dashboard error boundary.
+
+## Internationalization
+
+Add English and Portuguese strings for:
+
+- Navigation label: Analysis
+- Page title and description
+- Filter labels and presets
+- Grouping options
+- Chart titles
+- Summary labels
+- Empty and invalid states
+- Table headers
+- `Other` and `Uncategorized`
+
+## Testing Strategy
+
+### Unit Tests
+
+- Filter parsing:
+  - Default Last 3 months
+  - Each preset
+  - Custom date success and fallback
+  - Reversed date detection
+  - Grouping options and Adaptive resolution
+  - Account/category ID parsing
+- Analytics shaping:
+  - Totals respect date, account, and category filters
+  - Trend grouping produces daily, weekly, and monthly buckets
+  - Breakdown percentages are based on included totals
+  - Stacked charts keep top 10 categories and group the rest as `Other`
+- Category tree behavior:
+  - Parent toggles descendants
+  - Child overrides produce mixed parent state
+  - Uncategorized toggles are independent
+
+### E2E Tests
+
+- Authenticated user can navigate to `/analysis`.
+- Default Last 3 months view renders without errors.
+- Date preset changes update the URL and charts remain visible.
+- Account filter changes update the URL and charts remain visible.
+- Grouping changes update the URL and charts remain visible.
+- Category toggles update the URL and filtered sections render without crashing.
+
+## Acceptance Criteria
+
+- `/analysis` exists and is reachable from dashboard navigation.
+- The page defaults to Last 3 months, all accounts, all categories, and Adaptive grouping.
+- Users can filter by date range, account, grouping, and included categories.
+- Expense and income breakdowns are shown for the selected range.
+- Income vs expenses trend is grouped by the selected or resolved time window.
+- Expense and income stacked trend charts show top 10 categories plus `Other`.
+- Category trend table shows totals and period columns.
+- Invalid filters are handled gracefully.
+- The implementation includes unit and E2E coverage for the new behavior.

--- a/e2e/11-analysis.spec.ts
+++ b/e2e/11-analysis.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from './fixtures';
+import { login } from './helpers/auth';
+
+async function navigateToAnalysis(page: Parameters<typeof login>[0]) {
+  await login(page);
+
+  const analysisLink = page.getByRole('link', { name: /^analysis$/i }).first();
+  await expect(analysisLink).toBeVisible();
+  await analysisLink.click();
+
+  await page.waitForLoadState('networkidle');
+  await expect(page).toHaveURL(/\/analysis/);
+}
+
+test.describe('Transaction Analysis', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToAnalysis(page);
+  });
+
+  test('authenticated user can navigate to Analysis from the nav', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /^analysis$/i })).toBeVisible();
+    await expect(page.getByText(/explore income and expense trends/i)).toBeVisible();
+  });
+
+  test('default view shows major analysis sections', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /^analysis$/i })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /income vs\.? expenses/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /expense categor(y|ies)( trend| over time)/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /income categor(y|ies)( trend| over time)/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /category trend table/i })
+    ).toBeVisible();
+  });
+
+  test('grouping filter updates the URL', async ({ page }) => {
+    await page.getByRole('combobox', { name: /grouping/i }).click();
+    await page.getByRole('option', { name: /^monthly$/i }).click();
+
+    await expect(page).toHaveURL(/grouping=monthly/);
+    await expect(page.getByRole('heading', { name: /^analysis$/i })).toBeVisible();
+  });
+
+  test('date range filter updates the URL', async ({ page }) => {
+    await page.getByRole('combobox', { name: /date range/i }).click();
+    await page.getByRole('option', { name: /^last year$/i }).click();
+
+    await expect(page).toHaveURL(/preset=last-year/);
+    await expect(page.getByRole('heading', { name: /^analysis$/i })).toBeVisible();
+  });
+
+  test('category toggle keeps the page usable', async ({ page }) => {
+    const uncategorizedIncome = page.getByLabel(/^uncategorized income$/i);
+
+    await expect(uncategorizedIncome).toBeChecked();
+    await uncategorizedIncome.click();
+
+    await expect(uncategorizedIncome).not.toBeChecked();
+    await expect(page).toHaveURL(/uncategorizedIncome=0/);
+    await expect(page.getByRole('heading', { name: /^analysis$/i })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /income vs\.? expenses/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /category trend table/i })
+    ).toBeVisible();
+  });
+});

--- a/lib/analysis/filters.ts
+++ b/lib/analysis/filters.ts
@@ -1,0 +1,294 @@
+export type AnalysisDatePreset =
+  | 'this-month'
+  | 'last-month'
+  | 'last-3-months'
+  | 'last-90-days'
+  | 'this-year'
+  | 'ytd'
+  | 'last-year'
+  | 'custom';
+
+export type AnalysisGrouping = 'adaptive' | 'daily' | 'weekly' | 'monthly';
+export type ResolvedAnalysisGrouping = Exclude<AnalysisGrouping, 'adaptive'>;
+
+type QueryValue = string | string[] | undefined;
+export type AnalysisFilterSearchParams = Record<string, QueryValue>;
+
+export interface AnalysisFilters {
+  preset: AnalysisDatePreset;
+  from: string;
+  to: string;
+  accountId?: number;
+  grouping: AnalysisGrouping;
+  resolvedGrouping: ResolvedAnalysisGrouping;
+  includedCategoryIds: number[];
+  hasCategoryFilter: boolean;
+  includeUncategorizedIncome: boolean;
+  includeUncategorizedExpense: boolean;
+  hasInvalidDateRange: boolean;
+}
+
+interface ResolvedAnalysisDateRange {
+  preset: AnalysisDatePreset;
+  from: string;
+  to: string;
+  hasInvalidDateRange: boolean;
+}
+
+interface ResolveAnalysisDateRangeInput {
+  preset?: QueryValue;
+  from?: QueryValue;
+  to?: QueryValue;
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const POSITIVE_INTEGER_RE = /^\d+$/;
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const DATE_PRESETS: AnalysisDatePreset[] = [
+  'this-month',
+  'last-month',
+  'last-3-months',
+  'last-90-days',
+  'this-year',
+  'ytd',
+  'last-year',
+  'custom',
+];
+
+const GROUPINGS: AnalysisGrouping[] = ['adaptive', 'daily', 'weekly', 'monthly'];
+
+function firstValue(value: QueryValue): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+function allValues(value: QueryValue): string[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return value === undefined ? [] : [value];
+}
+
+function todayUtc(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+function formatUtcDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function daysInUtcMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+function addUtcMonths(date: Date, months: number): Date {
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth() + months;
+  const day = date.getUTCDate();
+  const targetFirst = new Date(Date.UTC(year, month, 1));
+  const targetYear = targetFirst.getUTCFullYear();
+  const targetMonth = targetFirst.getUTCMonth();
+  const targetDay = Math.min(day, daysInUtcMonth(targetYear, targetMonth));
+
+  return new Date(Date.UTC(targetYear, targetMonth, targetDay));
+}
+
+function parsePositiveIntegerValue(raw: string | undefined): number | undefined {
+  if (!raw || !POSITIVE_INTEGER_RE.test(raw)) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= POSTGRES_INTEGER_MAX
+    ? parsed
+    : undefined;
+}
+
+function parsePositiveInteger(value: QueryValue): number | undefined {
+  return parsePositiveIntegerValue(firstValue(value));
+}
+
+function parsePositiveIntegerList(value: QueryValue): number[] {
+  const ids = allValues(value)
+    .flatMap((raw) => raw.split(','))
+    .map((raw) => parsePositiveIntegerValue(raw.trim()))
+    .filter((id): id is number => id !== undefined);
+
+  return [...new Set(ids)].sort((a, b) => a - b);
+}
+
+function parseIsoDate(value: QueryValue): string | undefined {
+  const raw = firstValue(value);
+  if (!raw || !ISO_DATE_RE.test(raw)) {
+    return undefined;
+  }
+
+  const parsed = new Date(`${raw}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== raw
+    ? undefined
+    : raw;
+}
+
+function parsePreset(value: QueryValue): AnalysisDatePreset {
+  const raw = firstValue(value);
+  return raw && DATE_PRESETS.includes(raw as AnalysisDatePreset)
+    ? (raw as AnalysisDatePreset)
+    : 'last-3-months';
+}
+
+function parseGrouping(value: QueryValue): AnalysisGrouping {
+  const raw = firstValue(value);
+  return raw && GROUPINGS.includes(raw as AnalysisGrouping)
+    ? (raw as AnalysisGrouping)
+    : 'adaptive';
+}
+
+function parseIncludedBoolean(value: QueryValue): boolean {
+  const raw = firstValue(value);
+  if (raw === '0' || raw === 'false') {
+    return false;
+  }
+  if (raw === '1' || raw === 'true') {
+    return true;
+  }
+
+  return true;
+}
+
+function fallbackLastThreeMonths(): ResolvedAnalysisDateRange {
+  const today = todayUtc();
+
+  return {
+    preset: 'last-3-months',
+    from: formatUtcDate(addUtcMonths(today, -3)),
+    to: formatUtcDate(today),
+    hasInvalidDateRange: false,
+  };
+}
+
+export function resolveAnalysisDateRange(
+  input: ResolveAnalysisDateRangeInput
+): ResolvedAnalysisDateRange {
+  const preset = parsePreset(input.preset);
+  const today = todayUtc();
+  const year = today.getUTCFullYear();
+  const month = today.getUTCMonth();
+
+  if (preset === 'custom') {
+    const from = parseIsoDate(input.from);
+    const to = parseIsoDate(input.to);
+
+    if (!from || !to) {
+      return fallbackLastThreeMonths();
+    }
+
+    return {
+      preset,
+      from,
+      to,
+      hasInvalidDateRange: from > to,
+    };
+  }
+
+  if (preset === 'this-month') {
+    return {
+      preset,
+      from: formatUtcDate(new Date(Date.UTC(year, month, 1))),
+      to: formatUtcDate(today),
+      hasInvalidDateRange: false,
+    };
+  }
+
+  if (preset === 'last-month') {
+    return {
+      preset,
+      from: formatUtcDate(new Date(Date.UTC(year, month - 1, 1))),
+      to: formatUtcDate(new Date(Date.UTC(year, month, 0))),
+      hasInvalidDateRange: false,
+    };
+  }
+
+  if (preset === 'last-90-days') {
+    return {
+      preset,
+      from: formatUtcDate(new Date(today.getTime() - 90 * MS_PER_DAY)),
+      to: formatUtcDate(today),
+      hasInvalidDateRange: false,
+    };
+  }
+
+  if (preset === 'this-year' || preset === 'ytd') {
+    return {
+      preset,
+      from: formatUtcDate(new Date(Date.UTC(year, 0, 1))),
+      to: formatUtcDate(today),
+      hasInvalidDateRange: false,
+    };
+  }
+
+  if (preset === 'last-year') {
+    return {
+      preset,
+      from: formatUtcDate(new Date(Date.UTC(year - 1, 0, 1))),
+      to: formatUtcDate(new Date(Date.UTC(year - 1, 11, 31))),
+      hasInvalidDateRange: false,
+    };
+  }
+
+  return fallbackLastThreeMonths();
+}
+
+export function resolveAnalysisGrouping(
+  grouping: AnalysisGrouping,
+  from: string,
+  to: string
+): ResolvedAnalysisGrouping {
+  if (grouping !== 'adaptive') {
+    return grouping;
+  }
+
+  const fromTime = new Date(`${from}T00:00:00Z`).getTime();
+  const toTime = new Date(`${to}T00:00:00Z`).getTime();
+  const inclusiveDays = Math.floor((toTime - fromTime) / MS_PER_DAY) + 1;
+
+  if (inclusiveDays <= 45) {
+    return 'daily';
+  }
+  if (inclusiveDays <= 180) {
+    return 'weekly';
+  }
+
+  return 'monthly';
+}
+
+export function parseAnalysisFilters(searchParams: AnalysisFilterSearchParams): AnalysisFilters {
+  const dateRange = resolveAnalysisDateRange({
+    preset: searchParams.preset,
+    from: searchParams.from,
+    to: searchParams.to,
+  });
+  const grouping = parseGrouping(searchParams.grouping);
+  const accountId = parsePositiveInteger(searchParams.accountId);
+  const filters: AnalysisFilters = {
+    ...dateRange,
+    grouping,
+    resolvedGrouping: resolveAnalysisGrouping(grouping, dateRange.from, dateRange.to),
+    includedCategoryIds: parsePositiveIntegerList(searchParams.categories),
+    hasCategoryFilter: searchParams.categories !== undefined,
+    includeUncategorizedIncome: parseIncludedBoolean(searchParams.uncategorizedIncome),
+    includeUncategorizedExpense: parseIncludedBoolean(searchParams.uncategorizedExpense),
+  };
+
+  if (accountId) {
+    filters.accountId = accountId;
+  }
+
+  return filters;
+}

--- a/lib/analytics/transaction-analysis.ts
+++ b/lib/analytics/transaction-analysis.ts
@@ -155,6 +155,13 @@ export function buildAnalysisWhereClause(filters: AnalysisFilters): AnalysisWher
 }
 
 export function groupStackedTrendRows(rows: StackedTrendQueryRow[]): StackedTrendPoint[] {
+  return groupStackedTrendRowsForPeriods(rows);
+}
+
+function groupStackedTrendRowsForPeriods(
+  rows: StackedTrendQueryRow[],
+  selectedPeriods: string[] = []
+): StackedTrendPoint[] {
   const categoryTotals = new Map<string, { categoryPath: string; total: number }>();
 
   for (const row of rows) {
@@ -187,6 +194,10 @@ export function groupStackedTrendRows(rows: StackedTrendQueryRow[]): StackedTren
     periods.set(row.period, point);
   }
 
+  for (const period of selectedPeriods) {
+    periods.set(period, periods.get(period) ?? {});
+  }
+
   return [...periods.entries()]
     .sort(([periodA], [periodB]) => periodA.localeCompare(periodB))
     .map(([period, values]) => {
@@ -209,6 +220,11 @@ export async function getTransactionAnalysis(
 
   const { whereClause, params } = buildAnalysisWhereClause(filters);
   const periodSql = periodExpression(filters.resolvedGrouping);
+  const selectedPeriods = analysisPeriods(
+    filters.from,
+    filters.to,
+    filters.resolvedGrouping
+  );
   const includedSql = includedTransactionCondition(filters);
   const summary = await queryOne<AnalysisSummary>(
     `${CATEGORY_HIERARCHY_CTE}
@@ -280,13 +296,97 @@ export async function getTransactionAnalysis(
 
   return {
     summary: summary ?? { ...ZERO_SUMMARY },
-    incomeExpenseTrend,
+    incomeExpenseTrend: fillIncomeExpenseTrendPeriods(
+      incomeExpenseTrend,
+      selectedPeriods
+    ),
     expenseBreakdown,
     incomeBreakdown,
-    expenseStackedTrend: groupStackedTrendRows(expenseStackedTrendRows),
-    incomeStackedTrend: groupStackedTrendRows(incomeStackedTrendRows),
+    expenseStackedTrend: groupStackedTrendRowsForPeriods(
+      expenseStackedTrendRows,
+      selectedPeriods
+    ),
+    incomeStackedTrend: groupStackedTrendRowsForPeriods(
+      incomeStackedTrendRows,
+      selectedPeriods
+    ),
     categoryTrends: groupCategoryTrendRows(categoryTrendRows),
   };
+}
+
+function analysisPeriods(
+  from: string,
+  to: string,
+  grouping: ResolvedAnalysisGrouping
+): string[] {
+  const periods: string[] = [];
+  const end = parseIsoDate(to);
+  let current = periodStart(parseIsoDate(from), grouping);
+
+  while (current <= end) {
+    periods.push(formatPeriod(current, grouping));
+    current = incrementPeriod(current, grouping);
+  }
+
+  return periods;
+}
+
+function parseIsoDate(value: string): Date {
+  return new Date(`${value}T00:00:00Z`);
+}
+
+function periodStart(date: Date, grouping: ResolvedAnalysisGrouping): Date {
+  if (grouping === 'daily') {
+    return date;
+  }
+
+  if (grouping === 'weekly') {
+    const day = date.getUTCDay();
+    const daysFromMonday = (day + 6) % 7;
+    const start = new Date(date);
+    start.setUTCDate(start.getUTCDate() - daysFromMonday);
+    return start;
+  }
+
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+function incrementPeriod(
+  date: Date,
+  grouping: ResolvedAnalysisGrouping
+): Date {
+  const next = new Date(date);
+
+  if (grouping === 'daily') {
+    next.setUTCDate(next.getUTCDate() + 1);
+  } else if (grouping === 'weekly') {
+    next.setUTCDate(next.getUTCDate() + 7);
+  } else {
+    next.setUTCMonth(next.getUTCMonth() + 1);
+  }
+
+  return next;
+}
+
+function formatPeriod(date: Date, grouping: ResolvedAnalysisGrouping): string {
+  const isoDate = date.toISOString().slice(0, 10);
+  return grouping === 'monthly' ? isoDate.slice(0, 7) : isoDate;
+}
+
+function fillIncomeExpenseTrendPeriods(
+  rows: IncomeExpenseTrendPoint[],
+  selectedPeriods: string[]
+): IncomeExpenseTrendPoint[] {
+  const byPeriod = new Map(rows.map((row) => [row.period, row]));
+
+  return selectedPeriods.map(
+    (period) =>
+      byPeriod.get(period) ?? {
+        period,
+        income: '0.00',
+        expenses: '0.00',
+      }
+  );
 }
 
 function includedTransactionCondition(filters: AnalysisFilters): string {

--- a/lib/analytics/transaction-analysis.ts
+++ b/lib/analytics/transaction-analysis.ts
@@ -497,37 +497,41 @@ function categoryTrendQuery(
   whereClause: string,
   includedSql: string
 ): string {
-  return `${CATEGORY_HIERARCHY_CTE}
+  return `${CATEGORY_HIERARCHY_CTE},
+     categorized_transactions AS (
+       SELECT
+         ${periodSql} as period,
+         CASE
+           WHEN t.category_id IS NULL AND t.amount > 0 THEN 'income-uncategorized'
+           WHEN t.category_id IS NULL AND t.amount < 0 THEN 'expense-uncategorized'
+           ELSE ch.category_type || '-' || t.category_id::text
+         END as category_key,
+         CASE
+           WHEN t.category_id IS NULL AND t.amount > 0 THEN 'income'
+           WHEN t.category_id IS NULL AND t.amount < 0 THEN 'expense'
+           ELSE ch.category_type
+         END as category_type,
+         COALESCE(ch.full_path, 'Uncategorized') as category_path,
+         CASE
+           WHEN ch.category_type = 'income' THEN t.amount
+           WHEN ch.category_type = 'expense' THEN ABS(t.amount)
+           WHEN t.category_id IS NULL THEN ABS(t.amount)
+           ELSE 0
+         END as amount
+       FROM transactions t
+       LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+       ${whereClause}
+         AND (${includedSql})
+     )
      SELECT
-       ${periodSql} as period,
-       CASE
-         WHEN t.category_id IS NULL AND t.amount > 0 THEN 'income-uncategorized'
-         WHEN t.category_id IS NULL AND t.amount < 0 THEN 'expense-uncategorized'
-         ELSE ch.category_type || '-' || t.category_id::text
-       END as category_key,
-       CASE
-         WHEN t.category_id IS NULL AND t.amount > 0 THEN 'income'
-         WHEN t.category_id IS NULL AND t.amount < 0 THEN 'expense'
-         ELSE ch.category_type
-       END as category_type,
-       COALESCE(ch.full_path, 'Uncategorized') as category_path,
-       COALESCE(SUM(CASE
-         WHEN ch.category_type = 'income' THEN t.amount
-         WHEN ch.category_type = 'expense' THEN ABS(t.amount)
-         WHEN t.category_id IS NULL THEN ABS(t.amount)
-         ELSE 0
-       END), 0)::decimal(15,2) as amount
-     FROM transactions t
-     LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
-     ${whereClause}
-       AND (${includedSql})
-     GROUP BY ${periodSql}, category_key, category_type, category_path
-     HAVING COALESCE(SUM(CASE
-       WHEN ch.category_type = 'income' THEN t.amount
-       WHEN ch.category_type = 'expense' THEN ABS(t.amount)
-       WHEN t.category_id IS NULL THEN ABS(t.amount)
-       ELSE 0
-     END), 0) <> 0
+       period,
+       category_key,
+       category_type,
+       category_path,
+       COALESCE(SUM(amount), 0)::decimal(15,2) as amount
+     FROM categorized_transactions
+     GROUP BY period, category_key, category_type, category_path
+     HAVING COALESCE(SUM(amount), 0) <> 0
      ORDER BY category_path ASC, period ASC`;
 }
 

--- a/lib/analytics/transaction-analysis.ts
+++ b/lib/analytics/transaction-analysis.ts
@@ -1,0 +1,434 @@
+import { queryMany, queryOne } from '@/lib/db';
+import type { CategoryType } from '@/lib/db/types';
+import type {
+  AnalysisFilters,
+  ResolvedAnalysisGrouping,
+} from '@/lib/analysis/filters';
+
+export interface AnalysisSummary {
+  income: string;
+  expenses: string;
+}
+
+export interface IncomeExpenseTrendPoint {
+  period: string;
+  income: string;
+  expenses: string;
+}
+
+export interface AnalysisCategoryBreakdown {
+  category_id: number | null;
+  category_name: string;
+  category_path: string;
+  amount: string;
+  percentage: number;
+}
+
+export type StackedTrendPoint = {
+  period: string;
+} & Record<string, string>;
+
+export interface CategoryTrendRow {
+  categoryKey: string;
+  categoryType: CategoryType;
+  categoryPath: string;
+  total: string;
+  periods: Record<string, string>;
+}
+
+export interface TransactionAnalysisData {
+  summary: AnalysisSummary;
+  incomeExpenseTrend: IncomeExpenseTrendPoint[];
+  expenseBreakdown: AnalysisCategoryBreakdown[];
+  incomeBreakdown: AnalysisCategoryBreakdown[];
+  expenseStackedTrend: StackedTrendPoint[];
+  incomeStackedTrend: StackedTrendPoint[];
+  categoryTrends: CategoryTrendRow[];
+}
+
+export interface AnalysisWhereClause {
+  whereClause: string;
+  params: unknown[];
+}
+
+interface BreakdownQueryRow {
+  category_id: number | null;
+  category_name: string;
+  category_path: string;
+  amount: string;
+}
+
+interface StackedTrendQueryRow {
+  period: string;
+  category_key: string;
+  category_path: string;
+  amount: string;
+}
+
+interface CategoryTrendQueryRow extends StackedTrendQueryRow {
+  category_type: CategoryType;
+}
+
+const ZERO_SUMMARY: AnalysisSummary = {
+  income: '0.00',
+  expenses: '0.00',
+};
+
+const CATEGORY_HIERARCHY_CTE = `WITH RECURSIVE category_hierarchy AS (
+       SELECT
+         id,
+         name,
+         parent_id,
+         category_type,
+         name::text as full_path
+       FROM categories
+       WHERE parent_id IS NULL
+
+       UNION ALL
+
+       SELECT
+         c.id,
+         c.name,
+         c.parent_id,
+         c.category_type,
+         ch.full_path || ' > ' || c.name
+       FROM categories c
+       INNER JOIN category_hierarchy ch ON c.parent_id = ch.id
+     )`;
+
+export function emptyTransactionAnalysis(): TransactionAnalysisData {
+  return {
+    summary: { ...ZERO_SUMMARY },
+    incomeExpenseTrend: [],
+    expenseBreakdown: [],
+    incomeBreakdown: [],
+    expenseStackedTrend: [],
+    incomeStackedTrend: [],
+    categoryTrends: [],
+  };
+}
+
+export function periodExpression(grouping: ResolvedAnalysisGrouping): string {
+  if (grouping === 'daily') {
+    return "TO_CHAR(t.date, 'YYYY-MM-DD')";
+  }
+
+  if (grouping === 'weekly') {
+    return "TO_CHAR(DATE_TRUNC('week', t.date), 'YYYY-MM-DD')";
+  }
+
+  return "TO_CHAR(DATE_TRUNC('month', t.date), 'YYYY-MM')";
+}
+
+export function buildAnalysisWhereClause(filters: AnalysisFilters): AnalysisWhereClause {
+  const params: unknown[] = [filters.from, filters.to];
+  const clauses = ['t.date >= $1', 't.date <= $2'];
+
+  if (filters.accountId) {
+    params.push(filters.accountId);
+    clauses.push(`t.account_id = $${params.length}`);
+  }
+
+  if (filters.hasCategoryFilter) {
+    const categoryClauses: string[] = [];
+
+    if (filters.includedCategoryIds.length > 0) {
+      params.push(filters.includedCategoryIds);
+      categoryClauses.push(`t.category_id = ANY($${params.length}::int[])`);
+    }
+
+    if (filters.includeUncategorizedIncome) {
+      categoryClauses.push('(t.category_id IS NULL AND t.amount > 0)');
+    }
+
+    if (filters.includeUncategorizedExpense) {
+      categoryClauses.push('(t.category_id IS NULL AND t.amount < 0)');
+    }
+
+    clauses.push(`(${categoryClauses.length > 0 ? categoryClauses.join(' OR ') : 'FALSE'})`);
+  }
+
+  return {
+    whereClause: `WHERE ${clauses.join(' AND ')}`,
+    params,
+  };
+}
+
+export function groupStackedTrendRows(rows: StackedTrendQueryRow[]): StackedTrendPoint[] {
+  const categoryTotals = new Map<string, { categoryPath: string; total: number }>();
+
+  for (const row of rows) {
+    const total = categoryTotals.get(row.category_key) ?? {
+      categoryPath: row.category_path,
+      total: 0,
+    };
+    total.total += Number.parseFloat(row.amount);
+    categoryTotals.set(row.category_key, total);
+  }
+
+  const topCategoryKeys = new Set(
+    [...categoryTotals.entries()]
+      .sort(([, a], [, b]) => b.total - a.total)
+      .slice(0, 10)
+      .map(([categoryKey]) => categoryKey)
+  );
+  const periods = new Map<string, Record<string, number>>();
+
+  for (const row of rows) {
+    const point = periods.get(row.period) ?? {};
+    const categoryName = topCategoryKeys.has(row.category_key) ? row.category_path : 'Other';
+
+    point[categoryName] = (point[categoryName] ?? 0) + Number.parseFloat(row.amount);
+    periods.set(row.period, point);
+  }
+
+  return [...periods.entries()]
+    .sort(([periodA], [periodB]) => periodA.localeCompare(periodB))
+    .map(([period, values]) => {
+      const point: StackedTrendPoint = { period };
+
+      for (const [categoryName, amount] of Object.entries(values)) {
+        point[categoryName] = amount.toFixed(2);
+      }
+
+      return point;
+    });
+}
+
+export async function getTransactionAnalysis(
+  filters: AnalysisFilters
+): Promise<TransactionAnalysisData> {
+  if (filters.hasInvalidDateRange) {
+    return emptyTransactionAnalysis();
+  }
+
+  const { whereClause, params } = buildAnalysisWhereClause(filters);
+  const periodSql = periodExpression(filters.resolvedGrouping);
+  const includedSql = includedTransactionCondition(filters);
+  const summary = await queryOne<AnalysisSummary>(
+    `${CATEGORY_HIERARCHY_CTE}
+     SELECT
+       COALESCE(SUM(CASE
+         WHEN ch.category_type = 'income' THEN t.amount
+         ${filters.includeUncategorizedIncome ? 'WHEN t.category_id IS NULL AND t.amount > 0 THEN t.amount' : ''}
+         ELSE 0
+       END), 0)::decimal(15,2) as income,
+       COALESCE(SUM(CASE
+         WHEN ch.category_type = 'expense' THEN ABS(t.amount)
+         ${filters.includeUncategorizedExpense ? 'WHEN t.category_id IS NULL AND t.amount < 0 THEN ABS(t.amount)' : ''}
+         ELSE 0
+       END), 0)::decimal(15,2) as expenses
+     FROM transactions t
+     LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+     ${whereClause}
+       AND (${includedSql})`,
+    params
+  );
+
+  const incomeExpenseTrend = await queryMany<IncomeExpenseTrendPoint>(
+    `${CATEGORY_HIERARCHY_CTE}
+     SELECT
+       ${periodSql} as period,
+       COALESCE(SUM(CASE
+         WHEN ch.category_type = 'income' THEN t.amount
+         ${filters.includeUncategorizedIncome ? 'WHEN t.category_id IS NULL AND t.amount > 0 THEN t.amount' : ''}
+         ELSE 0
+       END), 0)::decimal(15,2) as income,
+       COALESCE(SUM(CASE
+         WHEN ch.category_type = 'expense' THEN ABS(t.amount)
+         ${filters.includeUncategorizedExpense ? 'WHEN t.category_id IS NULL AND t.amount < 0 THEN ABS(t.amount)' : ''}
+         ELSE 0
+       END), 0)::decimal(15,2) as expenses
+     FROM transactions t
+     LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+     ${whereClause}
+       AND (${includedSql})
+     GROUP BY ${periodSql}
+     ORDER BY period ASC`,
+    params
+  );
+
+  const expenseBreakdown = withPercentages(
+    await queryMany<BreakdownQueryRow>(
+      breakdownQuery('expense', whereClause, includedSql),
+      params
+    )
+  );
+  const incomeBreakdown = withPercentages(
+    await queryMany<BreakdownQueryRow>(
+      breakdownQuery('income', whereClause, includedSql),
+      params
+    )
+  );
+  const expenseStackedTrendRows = await queryMany<StackedTrendQueryRow>(
+    stackedTrendQuery('expense', periodSql, whereClause, includedSql),
+    params
+  );
+  const incomeStackedTrendRows = await queryMany<StackedTrendQueryRow>(
+    stackedTrendQuery('income', periodSql, whereClause, includedSql),
+    params
+  );
+  const categoryTrendRows = await queryMany<CategoryTrendQueryRow>(
+    categoryTrendQuery(periodSql, whereClause, includedSql),
+    params
+  );
+
+  return {
+    summary: summary ?? { ...ZERO_SUMMARY },
+    incomeExpenseTrend,
+    expenseBreakdown,
+    incomeBreakdown,
+    expenseStackedTrend: groupStackedTrendRows(expenseStackedTrendRows),
+    incomeStackedTrend: groupStackedTrendRows(incomeStackedTrendRows),
+    categoryTrends: groupCategoryTrendRows(categoryTrendRows),
+  };
+}
+
+function includedTransactionCondition(filters: AnalysisFilters): string {
+  const clauses = ["ch.category_type IN ('income', 'expense')"];
+
+  if (filters.includeUncategorizedIncome) {
+    clauses.push('(t.category_id IS NULL AND t.amount > 0)');
+  }
+
+  if (filters.includeUncategorizedExpense) {
+    clauses.push('(t.category_id IS NULL AND t.amount < 0)');
+  }
+
+  return clauses.join(' OR ');
+}
+
+function typeCondition(categoryType: CategoryType): string {
+  if (categoryType === 'income') {
+    return "(ch.category_type = 'income' OR (t.category_id IS NULL AND t.amount > 0))";
+  }
+
+  return "(ch.category_type = 'expense' OR (t.category_id IS NULL AND t.amount < 0))";
+}
+
+function amountExpression(categoryType: CategoryType): string {
+  return categoryType === 'income' ? 't.amount' : 'ABS(t.amount)';
+}
+
+function breakdownQuery(
+  categoryType: CategoryType,
+  whereClause: string,
+  includedSql: string
+): string {
+  const amountSql = amountExpression(categoryType);
+
+  return `${CATEGORY_HIERARCHY_CTE}
+     SELECT
+       t.category_id,
+       COALESCE(ch.name, 'Uncategorized') as category_name,
+       COALESCE(ch.full_path, 'Uncategorized') as category_path,
+       COALESCE(SUM(${amountSql}), 0)::decimal(15,2) as amount
+     FROM transactions t
+     LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+     ${whereClause}
+       AND (${includedSql})
+       AND ${typeCondition(categoryType)}
+     GROUP BY t.category_id, ch.name, ch.full_path
+     HAVING SUM(${amountSql}) <> 0
+     ORDER BY amount DESC`;
+}
+
+function stackedTrendQuery(
+  categoryType: CategoryType,
+  periodSql: string,
+  whereClause: string,
+  includedSql: string
+): string {
+  const amountSql = amountExpression(categoryType);
+
+  return `${CATEGORY_HIERARCHY_CTE}
+     SELECT
+       ${periodSql} as period,
+       CASE
+         WHEN t.category_id IS NULL THEN '${categoryType}-uncategorized'
+         ELSE '${categoryType}-' || t.category_id::text
+       END as category_key,
+       COALESCE(ch.full_path, 'Uncategorized') as category_path,
+       COALESCE(SUM(${amountSql}), 0)::decimal(15,2) as amount
+     FROM transactions t
+     LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+     ${whereClause}
+       AND (${includedSql})
+       AND ${typeCondition(categoryType)}
+     GROUP BY ${periodSql}, category_key, category_path
+     HAVING SUM(${amountSql}) <> 0
+     ORDER BY period ASC, amount DESC`;
+}
+
+function categoryTrendQuery(
+  periodSql: string,
+  whereClause: string,
+  includedSql: string
+): string {
+  return `${CATEGORY_HIERARCHY_CTE}
+     SELECT
+       ${periodSql} as period,
+       CASE
+         WHEN t.category_id IS NULL AND t.amount > 0 THEN 'income-uncategorized'
+         WHEN t.category_id IS NULL AND t.amount < 0 THEN 'expense-uncategorized'
+         ELSE ch.category_type || '-' || t.category_id::text
+       END as category_key,
+       CASE
+         WHEN t.category_id IS NULL AND t.amount > 0 THEN 'income'
+         WHEN t.category_id IS NULL AND t.amount < 0 THEN 'expense'
+         ELSE ch.category_type
+       END as category_type,
+       COALESCE(ch.full_path, 'Uncategorized') as category_path,
+       COALESCE(SUM(CASE
+         WHEN ch.category_type = 'income' THEN t.amount
+         WHEN ch.category_type = 'expense' THEN ABS(t.amount)
+         WHEN t.category_id IS NULL THEN ABS(t.amount)
+         ELSE 0
+       END), 0)::decimal(15,2) as amount
+     FROM transactions t
+     LEFT JOIN category_hierarchy ch ON t.category_id = ch.id
+     ${whereClause}
+       AND (${includedSql})
+     GROUP BY ${periodSql}, category_key, category_type, category_path
+     HAVING COALESCE(SUM(CASE
+       WHEN ch.category_type = 'income' THEN t.amount
+       WHEN ch.category_type = 'expense' THEN ABS(t.amount)
+       WHEN t.category_id IS NULL THEN ABS(t.amount)
+       ELSE 0
+     END), 0) <> 0
+     ORDER BY category_path ASC, period ASC`;
+}
+
+function withPercentages(rows: BreakdownQueryRow[]): AnalysisCategoryBreakdown[] {
+  const total = rows.reduce((sum, row) => sum + Number.parseFloat(row.amount), 0);
+
+  return rows.map((row) => ({
+    ...row,
+    percentage: total > 0 ? (Number.parseFloat(row.amount) / total) * 100 : 0,
+  }));
+}
+
+function groupCategoryTrendRows(rows: CategoryTrendQueryRow[]): CategoryTrendRow[] {
+  const categories = new Map<string, CategoryTrendRow & { numericTotal: number }>();
+
+  for (const row of rows) {
+    const amount = Number.parseFloat(row.amount);
+    const category = categories.get(row.category_key) ?? {
+      categoryKey: row.category_key,
+      categoryType: row.category_type,
+      categoryPath: row.category_path,
+      total: '0.00',
+      periods: {},
+      numericTotal: 0,
+    };
+
+    category.numericTotal += amount;
+    category.total = category.numericTotal.toFixed(2);
+    category.periods[row.period] = amount.toFixed(2);
+    categories.set(row.category_key, category);
+  }
+
+  return [...categories.values()]
+    .sort((a, b) => b.numericTotal - a.numericTotal)
+    .map(({ numericTotal: _numericTotal, ...category }) => category);
+}

--- a/lib/analytics/transaction-analysis.ts
+++ b/lib/analytics/transaction-analysis.ts
@@ -24,9 +24,20 @@ export interface AnalysisCategoryBreakdown {
   percentage: number;
 }
 
-export type StackedTrendPoint = {
+export interface StackedTrendSeries {
+  key: string;
+  name: string;
+}
+
+export interface StackedTrendPoint {
   period: string;
-} & Record<string, string>;
+  values: Record<string, string>;
+}
+
+export interface StackedTrendData {
+  series: StackedTrendSeries[];
+  points: StackedTrendPoint[];
+}
 
 export interface CategoryTrendRow {
   categoryKey: string;
@@ -41,8 +52,8 @@ export interface TransactionAnalysisData {
   incomeExpenseTrend: IncomeExpenseTrendPoint[];
   expenseBreakdown: AnalysisCategoryBreakdown[];
   incomeBreakdown: AnalysisCategoryBreakdown[];
-  expenseStackedTrend: StackedTrendPoint[];
-  incomeStackedTrend: StackedTrendPoint[];
+  expenseStackedTrend: StackedTrendData;
+  incomeStackedTrend: StackedTrendData;
   categoryTrends: CategoryTrendRow[];
 }
 
@@ -74,6 +85,8 @@ const ZERO_SUMMARY: AnalysisSummary = {
   expenses: '0.00',
 };
 
+const OTHER_STACK_KEY = 'other';
+
 const CATEGORY_HIERARCHY_CTE = `WITH RECURSIVE category_hierarchy AS (
        SELECT
          id,
@@ -102,8 +115,8 @@ export function emptyTransactionAnalysis(): TransactionAnalysisData {
     incomeExpenseTrend: [],
     expenseBreakdown: [],
     incomeBreakdown: [],
-    expenseStackedTrend: [],
-    incomeStackedTrend: [],
+    expenseStackedTrend: { series: [], points: [] },
+    incomeStackedTrend: { series: [], points: [] },
     categoryTrends: [],
   };
 }
@@ -154,14 +167,14 @@ export function buildAnalysisWhereClause(filters: AnalysisFilters): AnalysisWher
   };
 }
 
-export function groupStackedTrendRows(rows: StackedTrendQueryRow[]): StackedTrendPoint[] {
+export function groupStackedTrendRows(rows: StackedTrendQueryRow[]): StackedTrendData {
   return groupStackedTrendRowsForPeriods(rows);
 }
 
 function groupStackedTrendRowsForPeriods(
   rows: StackedTrendQueryRow[],
   selectedPeriods: string[] = []
-): StackedTrendPoint[] {
+): StackedTrendData {
   const categoryTotals = new Map<string, { categoryPath: string; total: number }>();
 
   for (const row of rows) {
@@ -173,24 +186,36 @@ function groupStackedTrendRowsForPeriods(
     categoryTotals.set(row.category_key, total);
   }
 
-  const topCategoryKeys = new Set(
-    [...categoryTotals.entries()]
-      .sort(
-        ([categoryKeyA, a], [categoryKeyB, b]) =>
-          b.total - a.total ||
-          a.categoryPath.localeCompare(b.categoryPath) ||
-          categoryKeyA.localeCompare(categoryKeyB)
-      )
-      .slice(0, 10)
-      .map(([categoryKey]) => categoryKey)
+  const sortedCategories = [...categoryTotals.entries()].sort(
+    ([categoryKeyA, a], [categoryKeyB, b]) =>
+      b.total - a.total ||
+      a.categoryPath.localeCompare(b.categoryPath) ||
+      categoryKeyA.localeCompare(categoryKeyB)
   );
+  const topCategories = sortedCategories.slice(0, 10);
+  const topCategoryKeys = new Set(
+    topCategories.map(([categoryKey]) => categoryKey)
+  );
+  const series: StackedTrendSeries[] = topCategories.map(
+    ([categoryKey, category]) => ({
+      key: categoryKey,
+      name: category.categoryPath,
+    })
+  );
+
+  if (sortedCategories.length > topCategories.length) {
+    series.push({ key: OTHER_STACK_KEY, name: 'Other' });
+  }
+
   const periods = new Map<string, Record<string, number>>();
 
   for (const row of rows) {
     const point = periods.get(row.period) ?? {};
-    const categoryName = topCategoryKeys.has(row.category_key) ? row.category_path : 'Other';
+    const seriesKey = topCategoryKeys.has(row.category_key)
+      ? row.category_key
+      : OTHER_STACK_KEY;
 
-    point[categoryName] = (point[categoryName] ?? 0) + Number.parseFloat(row.amount);
+    point[seriesKey] = (point[seriesKey] ?? 0) + Number.parseFloat(row.amount);
     periods.set(row.period, point);
   }
 
@@ -198,17 +223,19 @@ function groupStackedTrendRowsForPeriods(
     periods.set(period, periods.get(period) ?? {});
   }
 
-  return [...periods.entries()]
+  const points = [...periods.entries()]
     .sort(([periodA], [periodB]) => periodA.localeCompare(periodB))
-    .map(([period, values]) => {
-      const point: StackedTrendPoint = { period };
+    .map(([period, values]) => ({
+      period,
+      values: Object.fromEntries(
+        Object.entries(values).map(([seriesKey, amount]) => [
+          seriesKey,
+          amount.toFixed(2),
+        ])
+      ),
+    }));
 
-      for (const [categoryName, amount] of Object.entries(values)) {
-        point[categoryName] = amount.toFixed(2);
-      }
-
-      return point;
-    });
+  return { series, points };
 }
 
 export async function getTransactionAnalysis(

--- a/lib/analytics/transaction-analysis.ts
+++ b/lib/analytics/transaction-analysis.ts
@@ -168,7 +168,12 @@ export function groupStackedTrendRows(rows: StackedTrendQueryRow[]): StackedTren
 
   const topCategoryKeys = new Set(
     [...categoryTotals.entries()]
-      .sort(([, a], [, b]) => b.total - a.total)
+      .sort(
+        ([categoryKeyA, a], [categoryKeyB, b]) =>
+          b.total - a.total ||
+          a.categoryPath.localeCompare(b.categoryPath) ||
+          categoryKeyA.localeCompare(categoryKeyB)
+      )
       .slice(0, 10)
       .map(([categoryKey]) => categoryKey)
   );
@@ -429,6 +434,11 @@ function groupCategoryTrendRows(rows: CategoryTrendQueryRow[]): CategoryTrendRow
   }
 
   return [...categories.values()]
-    .sort((a, b) => b.numericTotal - a.numericTotal)
+    .sort(
+      (a, b) =>
+        b.numericTotal - a.numericTotal ||
+        a.categoryPath.localeCompare(b.categoryPath) ||
+        a.categoryKey.localeCompare(b.categoryKey)
+    )
     .map(({ numericTotal: _numericTotal, ...category }) => category);
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,6 +22,7 @@
     "dashboard": "Dashboard",
     "accounts": "Accounts",
     "transactions": "Transactions",
+    "analysis": "Analysis",
     "rentals": "Rentals",
     "units": "Units",
     "tenants": "Tenants",
@@ -94,6 +95,80 @@
     "fitid": "FITID",
     "refnum": "REFNUM",
     "originalMemo": "Original MEMO"
+  },
+  "analysis": {
+    "title": "Analysis",
+    "description": "Explore income and expense trends across accounts and categories.",
+    "filters": "Filters",
+    "dateRange": "Date range",
+    "dateRangePreset": "Date range",
+    "from": "From",
+    "to": "To",
+    "account": "Account",
+    "allAccounts": "All accounts",
+    "grouping": "Grouping",
+    "reset": "Reset",
+    "resetFilters": "Reset",
+    "categories": {
+      "title": "Categories",
+      "income": "Income categories",
+      "expense": "Expense categories",
+      "uncategorizedIncome": "Uncategorized income",
+      "uncategorizedExpense": "Uncategorized expense"
+    },
+    "income": "Income",
+    "expenses": "Expenses",
+    "category": "Category",
+    "type": "Type",
+    "total": "Total",
+    "uncategorizedIncome": "Uncategorized income",
+    "uncategorizedExpense": "Uncategorized expense",
+    "incomeVsExpensesTrend": "Income vs. expenses trend",
+    "expenseBreakdown": "Expense breakdown",
+    "incomeBreakdown": "Income breakdown",
+    "expenseStackedTrend": "Expense category trend",
+    "incomeStackedTrend": "Income category trend",
+    "categoryTrendTable": "Category trend table",
+    "empty": "No data for the selected filters.",
+    "emptyIncome": "No income data for the selected filters.",
+    "emptyExpenses": "No expense data for the selected filters.",
+    "invalidDateRange": "From date must be before to date.",
+    "presets": {
+      "thisMonth": "This month",
+      "lastMonth": "Last month",
+      "last3Months": "Last 3 months",
+      "last90Days": "Last 90 days",
+      "thisYear": "This year",
+      "ytd": "Year to date",
+      "lastYear": "Last year",
+      "custom": "Custom"
+    },
+    "groupings": {
+      "adaptive": "Adaptive",
+      "daily": "Daily",
+      "weekly": "Weekly",
+      "monthly": "Monthly"
+    },
+    "summary": {
+      "income": "Income",
+      "expenses": "Expenses"
+    },
+    "charts": {
+      "incomeExpenseTrend": "Income vs. expenses trend",
+      "incomeStackedTrend": "Income category trend",
+      "expenseStackedTrend": "Expense category trend",
+      "incomeBreakdown": "Income breakdown",
+      "expenseBreakdown": "Expense breakdown",
+      "categoryTrendTable": "Category trend table",
+      "empty": "No data for the selected filters."
+    },
+    "table": {
+      "category": "Category",
+      "type": "Type",
+      "total": "Total",
+      "income": "Income",
+      "expense": "Expense"
+    }
   },
   "expenseReports": {
     "title": "Expense Reports",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -20,6 +20,7 @@
     "dashboard": "Painel",
     "accounts": "Contas",
     "transactions": "Transações",
+    "analysis": "Análise",
     "rentals": "Aluguéis",
     "units": "Unidades",
     "tenants": "Inquilinos",
@@ -92,6 +93,80 @@
     "fitid": "FITID",
     "refnum": "REFNUM",
     "originalMemo": "MEMO Original"
+  },
+  "analysis": {
+    "title": "Análise",
+    "description": "Explore tendências de receitas e despesas por contas e categorias.",
+    "filters": "Filtros",
+    "dateRange": "Intervalo de datas",
+    "dateRangePreset": "Intervalo de datas",
+    "from": "De",
+    "to": "Até",
+    "account": "Conta",
+    "allAccounts": "Todas as contas",
+    "grouping": "Agrupamento",
+    "reset": "Redefinir",
+    "resetFilters": "Redefinir",
+    "categories": {
+      "title": "Categorias",
+      "income": "Categorias de receita",
+      "expense": "Categorias de despesa",
+      "uncategorizedIncome": "Receita sem categoria",
+      "uncategorizedExpense": "Despesa sem categoria"
+    },
+    "income": "Receita",
+    "expenses": "Despesas",
+    "category": "Categoria",
+    "type": "Tipo",
+    "total": "Total",
+    "uncategorizedIncome": "Receita sem categoria",
+    "uncategorizedExpense": "Despesa sem categoria",
+    "incomeVsExpensesTrend": "Tendência de receitas vs. despesas",
+    "expenseBreakdown": "Distribuição de despesas",
+    "incomeBreakdown": "Distribuição de receitas",
+    "expenseStackedTrend": "Tendência de despesas por categoria",
+    "incomeStackedTrend": "Tendência de receitas por categoria",
+    "categoryTrendTable": "Tabela de tendências por categoria",
+    "empty": "Nenhum dado para os filtros selecionados.",
+    "emptyIncome": "Nenhum dado de receita para os filtros selecionados.",
+    "emptyExpenses": "Nenhum dado de despesa para os filtros selecionados.",
+    "invalidDateRange": "A data inicial deve ser anterior à data final.",
+    "presets": {
+      "thisMonth": "Este mês",
+      "lastMonth": "Mês passado",
+      "last3Months": "Últimos 3 meses",
+      "last90Days": "Últimos 90 dias",
+      "thisYear": "Este ano",
+      "ytd": "Ano até agora",
+      "lastYear": "Ano passado",
+      "custom": "Personalizado"
+    },
+    "groupings": {
+      "adaptive": "Adaptativo",
+      "daily": "Diário",
+      "weekly": "Semanal",
+      "monthly": "Mensal"
+    },
+    "summary": {
+      "income": "Receita",
+      "expenses": "Despesas"
+    },
+    "charts": {
+      "incomeExpenseTrend": "Tendência de receitas vs. despesas",
+      "incomeStackedTrend": "Tendência de receitas por categoria",
+      "expenseStackedTrend": "Tendência de despesas por categoria",
+      "incomeBreakdown": "Distribuição de receitas",
+      "expenseBreakdown": "Distribuição de despesas",
+      "categoryTrendTable": "Tabela de tendências por categoria",
+      "empty": "Nenhum dado para os filtros selecionados."
+    },
+    "table": {
+      "category": "Categoria",
+      "type": "Tipo",
+      "total": "Total",
+      "income": "Receita",
+      "expense": "Despesa"
+    }
   },
   "expenseReports": {
     "title": "Relatórios de Despesas",


### PR DESCRIPTION
## Summary
- Add a protected /analysis page with account, date range, grouping, and category filters.
- Add income/expense trend, stacked category trends, selected-range category breakdowns, summary cards, and category trend table.
- Add analytics, URL parsing, i18n/nav wiring, unit tests, and focused E2E coverage for issue #49.

## Test Plan
- npm run lint
- npm test -- --run
- npx tsc --noEmit --incremental false
- npm run build
- npm run test:e2e -- e2e/11-analysis.spec.ts (blocked locally: Chromium cannot load libasound.so.2)