### PR TITLE
refactor: extract shared formatting utilities

### DIFF
--- a/__tests__/lib/i18n/format.test.ts
+++ b/__tests__/lib/i18n/format.test.ts
@@ -1,0 +1,21 @@
+import { formatCurrency, formatDate } from '@/lib/i18n/format';
+
+describe('i18n format utilities', () => {
+  it('formats currency using USD for English locale', () => {
+    expect(formatCurrency('1234.56', 'en')).toBe('$1,234.56');
+  });
+
+  it('formats currency using BRL for Brazilian Portuguese locale', () => {
+    expect(formatCurrency('-1234.56', 'pt-BR')).toBe('-R$\u00a01.234,56');
+  });
+
+  it('formats date-only strings without shifting the calendar day', () => {
+    expect(
+      formatDate('2024-01-15', 'en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    ).toBe('Jan 15, 2024');
+  });
+});

--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -2,19 +2,13 @@ import Link from 'next/link';
 import { getTranslations } from 'next-intl/server';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getAllAccountsWithBalances } from '@/lib/db/accounts';
+import { formatCurrency } from '@/lib/i18n/format';
 import { getLangFromUrl } from '@/lib/i18n/utils';
 
 export default async function AccountsPage() {
   const t = await getTranslations('accounts');
   const locale = await getLangFromUrl();
   const accounts = await getAllAccountsWithBalances();
-
-  const formatCurrency = (amount: string) => {
-    return new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: locale === 'pt-BR' ? 'BRL' : 'USD',
-    }).format(parseFloat(amount));
-  };
 
   return (
     <div className="space-y-6">
@@ -49,7 +43,7 @@ export default async function AccountsPage() {
                         : 'text-red-600'
                     }`}
                   >
-                    {formatCurrency(account.balance)}
+                    {formatCurrency(account.balance, locale)}
                   </div>
                 </CardContent>
               </Card>

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -10,27 +10,13 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { getRecentTransactions } from '@/lib/db/transactions';
+import { formatCurrency, formatDate } from '@/lib/i18n/format';
 import { getLangFromUrl } from '@/lib/i18n/utils';
 
 export async function RecentTransactions() {
   const t = await getTranslations('transactions');
   const locale = await getLangFromUrl();
   const transactions = await getRecentTransactions(10);
-
-  const formatCurrency = (amount: string) => {
-    return new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: locale === 'pt-BR' ? 'BRL' : 'USD',
-    }).format(parseFloat(amount));
-  };
-
-  const formatDate = (date: string) => {
-    return new Date(date).toLocaleDateString(locale, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
 
   return (
     <Card>
@@ -59,7 +45,11 @@ export async function RecentTransactions() {
               transactions.map((transaction) => (
                 <TableRow key={transaction.id}>
                   <TableCell>
-                    {formatDate(transaction.date)}
+                    {formatDate(transaction.date, locale, {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
                   </TableCell>
                   <TableCell>
                     <Link
@@ -80,7 +70,7 @@ export async function RecentTransactions() {
                         : 'text-red-600'
                     }`}
                   >
-                    {formatCurrency(transaction.amount)}
+                    {formatCurrency(transaction.amount, locale)}
                   </TableCell>
                 </TableRow>
               ))

--- a/components/dashboard/summary-cards.tsx
+++ b/components/dashboard/summary-cards.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from 'next-intl/server';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getAccountSummary } from '@/lib/analytics/cash-flow';
 import { getRentalOperationSummary } from '@/lib/analytics/rentals-operations';
+import { formatCurrency } from '@/lib/i18n/format';
 import { getLangFromUrl } from '@/lib/i18n/utils';
 import Link from 'next/link';
 
@@ -10,13 +11,6 @@ export async function SummaryCards() {
   const locale = await getLangFromUrl();
   const summary = await getAccountSummary();
   const rentalSummary = await getRentalOperationSummary();
-
-  const formatCurrency = (amount: string) => {
-    return new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: locale === 'pt-BR' ? 'BRL' : 'USD',
-    }).format(parseFloat(amount));
-  };
 
   return (
     <>
@@ -29,7 +23,7 @@ export async function SummaryCards() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
-              {formatCurrency(summary.total_balance)}
+              {formatCurrency(summary.total_balance, locale)}
             </div>
           </CardContent>
         </Card>
@@ -42,7 +36,7 @@ export async function SummaryCards() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-green-600">
-              {formatCurrency(summary.monthly_income)}
+              {formatCurrency(summary.monthly_income, locale)}
             </div>
           </CardContent>
         </Card>
@@ -55,7 +49,7 @@ export async function SummaryCards() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-red-600">
-              {formatCurrency(summary.monthly_expenses)}
+              {formatCurrency(summary.monthly_expenses, locale)}
             </div>
           </CardContent>
         </Card>
@@ -74,7 +68,7 @@ export async function SummaryCards() {
                   : 'text-red-600'
               }`}
             >
-              {formatCurrency(summary.net_cash_flow)}
+              {formatCurrency(summary.net_cash_flow, locale)}
             </div>
           </CardContent>
         </Card>

--- a/components/transactions/transaction-table.tsx
+++ b/components/transactions/transaction-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import {
   Table,
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/dialog';
 import { TransactionWithDetails } from '@/lib/db/types';
 import { deleteTransaction } from '@/lib/actions/transactions';
+import { formatCurrency, formatDate } from '@/lib/i18n/format';
 import { Info } from 'lucide-react';
 
 interface TransactionTableProps {
@@ -37,25 +38,6 @@ export function TransactionTable({
   const [deleting, setDeleting] = useState<number | null>(null);
   const [infoTransaction, setInfoTransaction] =
     useState<TransactionWithDetails | null>(null);
-
-  const formatCurrency = useMemo(() => {
-    return (amount: string) => {
-      return new Intl.NumberFormat(lang, {
-        style: 'currency',
-        currency: lang === 'pt-BR' ? 'BRL' : 'USD',
-      }).format(parseFloat(amount));
-    };
-  }, [lang]);
-
-  const formatDate = (date: string) => {
-    return new Date(
-      typeof date === 'string' ? date + 'T00:00:00' : date
-    ).toLocaleDateString(lang, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric'
-    });
-  };
 
   const handleDelete = async (id: number, accountId: number) => {
     if (!confirm(t('deleteConfirm'))) {
@@ -95,7 +77,11 @@ export function TransactionTable({
           transactions.map((transaction) => (
             <TableRow key={transaction.id}>
               <TableCell>
-                {formatDate(transaction.date)}
+                {formatDate(transaction.date, lang, {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
               </TableCell>
               <TableCell>{transaction.account_name}</TableCell>
               <TableCell>{transaction.payee}</TableCell>
@@ -109,7 +95,7 @@ export function TransactionTable({
                     : 'text-red-600'
                 }`}
               >
-                {formatCurrency(transaction.amount)}
+                {formatCurrency(transaction.amount, lang)}
               </TableCell>
               <TableCell className="max-w-xs truncate">
                 {transaction.comment}

--- a/lib/i18n/format.ts
+++ b/lib/i18n/format.ts
@@ -1,0 +1,38 @@
+type CurrencyAmount = string | number;
+type DateValue = string | Date;
+
+export function getCurrencyForLocale(locale: string): 'BRL' | 'USD' {
+  return locale === 'pt-BR' ? 'BRL' : 'USD';
+}
+
+export function formatCurrency(amount: CurrencyAmount, locale: string): string {
+  const numericAmount =
+    typeof amount === 'number' ? amount : Number.parseFloat(amount);
+
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: getCurrencyForLocale(locale),
+  }).format(numericAmount);
+}
+
+export function formatDate(
+  date: DateValue,
+  locale: string,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(toDate(date));
+}
+
+function toDate(date: DateValue): Date {
+  if (date instanceof Date) {
+    return date;
+  }
+
+  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!dateOnlyMatch) {
+    return new Date(date);
+  }
+
+  const [, year, month, day] = dateOnlyMatch;
+  return new Date(Number(year), Number(month) - 1, Number(day));
+}


### PR DESCRIPTION
## Summary
- add shared locale-aware currency/date formatting utilities
- replace duplicated currency/date formatters in dashboard, accounts, and transaction table UI
- add focused formatter coverage for USD, BRL, and date-only strings

## Verification
- npm run lint
- npm test -- --run

## Notes
- `npm run test:e2e` currently has unrelated failures in navigation/rentals specs in this workspace; the formatter-focused and full unit checks pass.

Closes #64
