### PR TITLE
fix: preserve locale in dashboard navigation

### DIFF
--- a/components/dashboard/nav.tsx
+++ b/components/dashboard/nav.tsx
@@ -1,16 +1,14 @@
 'use client';
 
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { ChevronDown } from 'lucide-react';
 
 export function DashboardNav() {
   const t = useTranslations('nav');
-  const searchParams = useSearchParams();
-  const lang = searchParams.get('lang') || 'en';
+  const lang = useLocale();
   const [rentalsOpen, setRentalsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 

--- a/e2e/09-translations.spec.ts
+++ b/e2e/09-translations.spec.ts
@@ -42,23 +42,40 @@ test.describe('Translations', () => {
 
   test('maintains Portuguese locale when navigating to accounts page', async ({ page }) => {
     await page.goto('/?lang=pt-BR');
-    
-    await page.waitForURL(/\/\?.*/);
-    
+
+    await expect
+      .poll(async () => {
+        const cookies = await page.context().cookies();
+        return cookies.find((cookie) => cookie.name === 'locale')?.value;
+      })
+      .toBe('pt-BR');
+
     await page.goto('/accounts');
     await page.waitForURL(/.*\/accounts/);
-    
+
+    expect(new URL(page.url()).searchParams.get('lang')).toBeNull();
     await expect(page.getByRole('heading', { name: /contas/i })).toBeVisible();
+
+    await expect(page.getByRole('link', { name: /configurações/i })).toHaveAttribute(
+      'href',
+      '/settings?lang=pt-BR'
+    );
   });
 
   test('maintains Portuguese locale when navigating to settings page', async ({ page }) => {
     await page.goto('/?lang=pt-BR');
-    
-    await page.waitForURL(/\/\?.*/);
-    
+
+    await expect
+      .poll(async () => {
+        const cookies = await page.context().cookies();
+        return cookies.find((cookie) => cookie.name === 'locale')?.value;
+      })
+      .toBe('pt-BR');
+
     await page.goto('/settings');
     await page.waitForURL(/.*\/settings/);
-    
+
+    expect(new URL(page.url()).searchParams.get('lang')).toBeNull();
     await expect(page.getByRole('heading', { name: /configurações/i })).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
- Use the active next-intl locale for dashboard navigation links instead of defaulting to English when the URL has no lang query param
- Strengthen translations E2E coverage for cookie-based locale persistence after direct URL navigation

Fixes #63

## Verification
- npm run lint
- npm test -- --run
- npm run test:e2e -- e2e/09-translations.spec.ts